### PR TITLE
dts: boards: update the flash-partition of rtl8762gn_evb

### DIFF
--- a/boards/arm/rtl8762gn_evb/rtl8762gn_evb.dts
+++ b/boards/arm/rtl8762gn_evb/rtl8762gn_evb.dts
@@ -9,6 +9,7 @@
 	chosen {
 		zephyr,sram = &ram_data;
 		zephyr,flash = &flash;
+		zephyr,code-partition = &app_partition;
 		zephyr,itcm = &ram_code;
 		zephyr,console = &uart2;
 		zephyr,shell-uart = &uart2;
@@ -22,22 +23,46 @@
 
 };
 
-&fmc {
-	status = "okay";
-};
-
 &flash {
 	partitions {
 		compatible = "fixed-partitions";
 		#address-cells = <1>;
 		#size-cells = <1>;
-		app_partition: partition@0 {
-			label = "app-image";
-			reg = <0x0 DT_SIZE_K(628)>;
+		reserved: partition@0 {
+			label = "reserved-image";
+			reg = <0x0 DT_SIZE_K(4)>;
 		};
-		storage_partition: partition@9d000 {
+		config_file: partition@1000 {
+			label = "config-file-image";
+			reg = <0x1000 DT_SIZE_K(4)>;
+		};
+		boot_patch_0: partition@2000 {
+			label = "boot-patch-0-image";
+			reg = <0x2000 DT_SIZE_K(32)>;
+		};
+		boot_patch_1: partition@a000 {
+			label = "boot-patch-1-image";
+			reg = <0xA000 DT_SIZE_K(32)>;
+		};
+		ota_header: partition@12000 {
+			label = "ota-header-image";
+			reg = <0x12000 DT_SIZE_K(4)>;
+		};
+		system_patch: partition@13000 {
+			label = "system-patch-image";
+			reg = <0x13000 DT_SIZE_K(32)>;
+		};
+		stack_patch: partition@1b000 {
+			label = "stack-patch-image";
+			reg = <0x1B000 DT_SIZE_K(72)>;
+		};
+		app_partition: partition@2d000 {
+			label = "app-image";
+			reg = <0x2D000 DT_SIZE_K(828)>;
+		};
+		storage_partition: partition@fc000 {
 			label = "storage";
-			reg = <0x9d000 DT_SIZE_K(16)>;
+			reg = <0xFC000 DT_SIZE_K(16)>;
 		};
 	};
 };
@@ -45,6 +70,7 @@
 &cpu {
 	clock-frequency = <40000000>;
 };
+
 &uart2 {
 	pinctrl-0 = <&uart2_default>;
 	pinctrl-names = "default";
@@ -53,8 +79,4 @@
 	parity = "none";
 	stop-bits = "1";
 	data-bits = <8>;
-};
-
-&trng {
-	status = "okay";
 };

--- a/boards/arm/rtl8762gn_evb/rtl8762gn_evb_defconfig
+++ b/boards/arm/rtl8762gn_evb/rtl8762gn_evb_defconfig
@@ -46,3 +46,6 @@ CONFIG_OUTPUT_DISASSEMBLY=y
 
 # speed up the code execution
 CONFIG_SPEED_OPTIMIZATIONS=y
+
+# link application into the the flash partition selected by the zephyr,code-partition property in /chosen in devicetree
+CONFIG_USE_DT_CODE_PARTITION=y

--- a/dts/arm/realtek/rtl8762gn_evb.dtsi
+++ b/dts/arm/realtek/rtl8762gn_evb.dtsi
@@ -39,7 +39,7 @@
 			device_type = "secure rom code region";
 			reg = <0x0 DT_SIZE_K(116)>;
 		};
-        rom_ns: memory@1D000 {
+        rom_ns: memory@1d000 {
 			device_type = "non-secure rom code region";
 			reg = <0x1D000 0x19000>;
 		};
@@ -75,12 +75,13 @@
 			reg = <0x40022000 0x400>;
 			#address-cells = <1>;
 			#size-cells = <1>;
+			status = "okay";
 
-			flash: flash@405f000 {
+			flash: flash@4000000 {
 				compatible = "soc-nv-flash";
 				write-block-size = <1>;
 				erase-block-size = <4096>;
-				reg = <0x405f000 DT_SIZE_K(644)>;
+				reg = <0x4000000 DT_SIZE_K(1024)>;
 			};
 		};
 
@@ -456,6 +457,7 @@
 		trng: trng@400c2400 {
 			compatible = "realtek,rtl87x2g-trng";
 			reg = <0x400c2400 0x68>;
+			status = "okay";
         };
 
 		usb: usb@40100000 {


### PR DESCRIPTION
Update the flash partition configuration in the devicetree of rtl8762gn_evb. Config File, boot patch, ota header, system patch and stack patch are essentials for the rtl87x2g series SoC.
Enable CONFIG_USE_DT_CODE_PARTITION by default for rtl8762gn_evb to link application into the the flash partition selected by the zephyr,code-partition property in /chosen in devicetree.

Also I modify stack patch size from 60K to 72K, and remove upperstack image size. So we need update the **new OTA header and the flash_map.ini**. And right now the zephyr-app is begin at 0x402d000. 