### PR TITLE
Add version info to rtk img header

### DIFF
--- a/soc/arm/realtek_bee/rtl87x2g/image_header.c
+++ b/soc/arm/realtek_bee/rtl87x2g/image_header.c
@@ -1,8 +1,8 @@
 #include <patch_header_check.h>
 #include <stdlib.h>
 #include <rom_uuid.h>
+#include <version.h>
 extern void z_arm_reset(void);
-
 const T_IMG_HEADER_FORMAT img_header __attribute__((section(".image_header"))) =
 {
     .auth =
@@ -20,6 +20,12 @@ const T_IMG_HEADER_FORMAT img_header __attribute__((section(".image_header"))) =
         .ctrl_flag.not_obsolete = 1,
         .image_id = IMG_MCUAPP,
         .payload_len = 0x100,
+    },
+    .git_ver =
+    {
+        .ver_info.sub_version._version_major = KERNEL_VERSION_MAJOR,
+        .ver_info.sub_version._version_minor = KERNEL_VERSION_MINOR,
+        .ver_info.sub_version._version_revision = KERNEL_PATCHLEVEL,
     },
     .uuid = DEFINE_symboltable_uuid,
     .exe_base = (unsigned int)z_arm_reset,


### PR DESCRIPTION
use zephyr kernel version to fillout the git_ver in rtk image header