### PR TITLE
drivers: add pm function for drivers

### DIFF
--- a/drivers/gpio/gpio_rtl87x2g.h
+++ b/drivers/gpio/gpio_rtl87x2g.h
@@ -50,6 +50,9 @@ struct gpio_rtl87x2g_data
     const struct device *dev;
     sys_slist_t cb;
     uint8_t pin_debounce_ms[32];
+#ifdef CONFIG_PM_DEVICE
+    GPIOStoreReg_Typedef store_buf;
+#endif
 };
 
 /**

--- a/drivers/gpio/gpio_rtl87x2g.h
+++ b/drivers/gpio/gpio_rtl87x2g.h
@@ -41,6 +41,15 @@ struct gpio_rtl87x2g_config
     struct gpio_rtl87x2g_irq_info *irq_info;
 };
 
+#ifdef CONFIG_PM_DEVICE
+struct pm_pad_node
+{
+    uint8_t pad_num;
+    uint8_t gpio_num;
+    struct pm_pad_node* next;
+};
+#endif
+
 /**
  * @brief driver data
  */
@@ -52,6 +61,8 @@ struct gpio_rtl87x2g_data
     uint8_t pin_debounce_ms[32];
 #ifdef CONFIG_PM_DEVICE
     GPIOStoreReg_Typedef store_buf;
+    struct pm_pad_node* pm_pad_node_head;
+    struct k_heap *heap;
 #endif
 };
 

--- a/drivers/pinctrl/pinctrl_rtl87x2g.c
+++ b/drivers/pinctrl/pinctrl_rtl87x2g.c
@@ -19,11 +19,13 @@ static void pinctrl_configure_pin(const pinctrl_soc_pin_t *pin)
     uint32_t cfg_drv = pin[0].drive;
     uint32_t cfg_pull = pin[0].pull;
     uint32_t cfg_pull_strength = pin[0].pull_strength;
+    uint32_t cfg_wakeup_high = pin[0].wakeup_high;
+    uint32_t cfg_wakeup_low = pin[0].wakeup_low;
 
 #if DBG_DIRECT_SHOW
-    DBG_DIRECT("[pinctrl_configure_pin] cfg_fun=%d, cfg_pin=%d,"
-               "cfg_dir=%d, cfg_drv=%d , cfg_pull=%d, cfg_pull_strength=%d", \
-               cfg_fun, cfg_pin, cfg_dir, cfg_drv, cfg_pull, cfg_pull_strength);
+    DBG_DIRECT("[pinctrl_configure_pin] cfg_fun=%d, cfg_pin=%d, cfg_dir=%d,"
+               " cfg_drv=%d , cfg_pull=%d, cfg_pull_strength=%d, cfg_wakeup_high=%d, cfg_wakeup_low=%d", \
+               cfg_fun, cfg_pin, cfg_dir, cfg_drv, cfg_pull, cfg_pull_strength, cfg_wakeup_high, cfg_wakeup_low);
 #endif
 
     Pad_SetPullStrength(cfg_pin, cfg_pull_strength);
@@ -43,6 +45,14 @@ static void pinctrl_configure_pin(const pinctrl_soc_pin_t *pin)
         Pinmux_Config(cfg_pin, cfg_fun);
     }
 
+    if (cfg_wakeup_high)
+    {
+        System_WakeUpPinEnable(cfg_pin, PAD_WAKEUP_POL_HIGH, PAD_WAKEUP_DEB_DISABLE);
+    }
+    else if (cfg_wakeup_low)
+    {
+        System_WakeUpPinEnable(cfg_pin, PAD_WAKEUP_POL_LOW, PAD_WAKEUP_DEB_DISABLE);
+    }
 }
 
 int pinctrl_configure_pins(const pinctrl_soc_pin_t *pins, uint8_t pin_cnt,

--- a/drivers/serial/uart_rtl87x2g.h
+++ b/drivers/serial/uart_rtl87x2g.h
@@ -67,6 +67,9 @@ struct uart_rtl87x2g_data
     uint8_t *rx_next_buffer;
     size_t rx_next_buffer_len;
 #endif
+#ifdef CONFIG_PM_DEVICE
+    UARTStoreReg_Typedef store_buf;
+#endif
 };
 
 #endif  /* ZEPHYR_DRIVERS_SERIAL_UART_RTL87X2G_H_ */

--- a/dts/bindings/kscan/realtek,rtl87x2g-kscan.yaml
+++ b/dts/bindings/kscan/realtek,rtl87x2g-kscan.yaml
@@ -53,6 +53,9 @@ properties:
   pinctrl-0:
     required: true
 
+  pinctrl-1:
+    required: false
+
   pinctrl-names:
     required: true
 

--- a/dts/bindings/pinctrl/realtek,rtl87x2g-pinctrl.yaml
+++ b/dts/bindings/pinctrl/realtek,rtl87x2g-pinctrl.yaml
@@ -80,3 +80,10 @@ child-binding:
         type: boolean
         description: enable pull-strong resistor
 
+      wakeup-high:
+        type: boolean
+        description: enable wakeup high function
+
+      wakeup-low:
+        type: boolean
+        description: enable wakeup low function

--- a/soc/arm/realtek_bee/rtl87x2g/pinctrl_soc.h
+++ b/soc/arm/realtek_bee/rtl87x2g/pinctrl_soc.h
@@ -29,6 +29,8 @@ typedef struct {
         uint32_t dir : 1;
         uint32_t pull_strength : 1;
         uint32_t fun : 16;
+        uint32_t wakeup_high : 1;
+        uint32_t wakeup_low : 1;
 } pinctrl_soc_pin;
 
 typedef pinctrl_soc_pin pinctrl_soc_pin_t;
@@ -48,6 +50,8 @@ typedef pinctrl_soc_pin pinctrl_soc_pin_t;
 		.dir = RTL87X2G_GET_DIR(DT_PROP_BY_IDX(node_id, prop, idx)),		\
 		.pull_strength = DT_PROP(node_id, bias_pull_strong),		\
 		.fun = RTL87X2G_GET_FUN(DT_PROP_BY_IDX(node_id, prop, idx)),		\
+		.wakeup_high = DT_PROP(node_id, wakeup_high),		\
+		.wakeup_low = DT_PROP(node_id, wakeup_low),		\
 	},
 
 /**


### PR DESCRIPTION
1,Add suspend/resume functions for drivers;
2.Add usb pm;
3.Add wakeup pin configure for pinctrl;
4.Add pad wakeup for kscan;
5.Add pad output in sleep status for pwm;
6.Add pad output in sleep status for gpio
This PR should be used together with https://github.com/rtkconnectivity/hal_realtek/pull/20