### PR TITLE
soc: rtl87x2g: workaround for zephyr svc vector

### DIFF
--- a/soc/arm/realtek_bee/rtl87x2g/soc.c
+++ b/soc/arm/realtek_bee/rtl87x2g/soc.c
@@ -29,164 +29,163 @@ extern void PF_RTC_Handler(void);
 
 extern void z_arm_nmi(void);
 extern void _isr_wrapper(void);
+extern void z_arm_svc(void);
+
+extern const T_ROM_HEADER_FORMAT nonsecure_rom_header;
 
 #define VECTOR_ADDRESS ((uintptr_t)_vector_start)
 
 /*
-    rtk_rom_irq_connect() calls IRQ_CONNECT to register isr to zephyr's vector table/sw isr table.
-    In zephyr app, we discard rtk's RamVectorTable, but use zephyr's build-time-generated vector table instead.
-    
-    Note: IRQ_CONNECT will set the interrupt's priority again.
-*/
+ *  rtk_rom_irq_connect() calls IRQ_CONNECT to register isr to
+ *	zephyr's vector table/sw isr table. In zephyr app, we discard
+ *	rtk's RamVectorTable, but use zephyr's build-time-generated
+ *	vector table instead.
+ *	Note: IRQ_CONNECT will set the interrupt's priority again.
+ */
 void rtk_rom_irq_connect(void)
 {
-    IRQ_CONNECT(WDT_IRQn, 2, HardFault_Handler_Rom, NULL, 0);
-    IRQ_CONNECT(RXI300_IRQn, 0, HardFault_Handler_Rom, NULL, 0);
-    IRQ_CONNECT(RXI300_SEC_IRQn, 0, HardFault_Handler_Rom, NULL, 0);
-    IRQ_CONNECT(GDMA0_Channel9_IRQn, 6, GDMA0_Channel9_Handler, NULL, 0);
-    IRQ_CONNECT(PF_RTC_IRQn, 0, PF_RTC_Handler, NULL, 0);
-    IRQ_CONNECT(BTMAC_IRQn, 1, BTMAC_Handler, NULL, 0);
-    IRQ_CONNECT(BTMAC_WRAP_AROUND_IRQn, 0, HardFault_Handler_Rom, NULL, 0);
-    // IRQ_CONNECT(Flash_SEC_IRQn, 5, Flash_SEC_Handler, NULL, 0);//secure ISR register, have not found solution yet
+	IRQ_CONNECT(WDT_IRQn, 2, HardFault_Handler_Rom, NULL, 0);
+	IRQ_CONNECT(RXI300_IRQn, 0, HardFault_Handler_Rom, NULL, 0);
+	IRQ_CONNECT(RXI300_SEC_IRQn, 0, HardFault_Handler_Rom, NULL, 0);
+	IRQ_CONNECT(GDMA0_Channel9_IRQn, 6, GDMA0_Channel9_Handler, NULL, 0);
+	IRQ_CONNECT(PF_RTC_IRQn, 0, PF_RTC_Handler, NULL, 0);
+	IRQ_CONNECT(BTMAC_IRQn, 1, BTMAC_Handler, NULL, 0);
+	IRQ_CONNECT(BTMAC_WRAP_AROUND_IRQn, 0, HardFault_Handler_Rom, NULL, 0);
+	/* IRQ_CONNECT(Flash_SEC_IRQn, 5, Flash_SEC_Handler, NULL, 0); */
 }
 
 static int rtk_platform_init(void)
 {
 /*
-* SCB->VTOR points to zephyr's vector table which is placed in flash.
-* However, vector table place in flash will trigger hardfault when flash erasing.
-* So we need  point SCB->VTOR to RAM vector table, and copy zephyr's vector table to RAM.
-*/ 
-    size_t vector_size = (size_t)_vector_end - (size_t)_vector_start;
+ * SCB->VTOR points to zephyr's vector table which is placed in flash.
+ * However, vector table place in flash will trigger hardfault when flash erasing.
+ * So point SCB->VTOR to RAM vector table, and copy zephyr's vector table to RAM.
+ */
+	size_t vector_size = (size_t)_vector_end - (size_t)_vector_start;
 #if (CONFIG_TRUSTED_EXECUTION_NONSECURE==1)
-    //tz enabled
-    SCB->VTOR = (uint32_t)NS_RAM_VECTOR_ADDR;
-    (void)memcpy((void *)NS_RAM_VECTOR_ADDR, _vector_start, vector_size);
+	/* tz enabled */
+	SCB->VTOR = (uint32_t)NS_RAM_VECTOR_ADDR;
+	(void)memcpy((void *)NS_RAM_VECTOR_ADDR, _vector_start, vector_size);
 #else
-    //tz disabled
-    SCB->VTOR = (uint32_t)S_RAM_VECTOR_ADDR;
-    (void)memcpy((void *)S_RAM_VECTOR_ADDR, _vector_start, vector_size);
+	/* tz disabled */
+	SCB->VTOR = (uint32_t)S_RAM_VECTOR_ADDR;
+	(void)memcpy((void *)S_RAM_VECTOR_ADDR, _vector_start, vector_size);
 #endif
-    
-    /* connect rtk-rom-irq to zephyr's vector table, also will reset priority here!*/
-    rtk_rom_irq_connect();
+	/* connect rtk-rom-irq to zephyr's vector table, also will reset priority here!*/
+	rtk_rom_irq_connect();
 
-    os_zephyr_patch_init();
+	os_zephyr_patch_init();
 
-    os_init();
+	os_init();
 
-    os_pm_init();
+	os_pm_init();
 
-    secure_os_func_ptr_init();
+	secure_os_func_ptr_init();
+	RamVectorTableUpdate(SVC_VECTORn, (IRQ_Fun)z_arm_svc);
 
-    secure_platform_func_ptr_init();
+	secure_platform_func_ptr_init();
 
-    mpu_setup();
+	mpu_setup();
 
-    set_active_mode_clk_src();
+	set_active_mode_clk_src();
 
-    log_module_trace_init(NULL);
-    log_buffer_init();
-    log_gdma_init();
-    RamVectorTableUpdate(GDMA0_Channel9_VECTORn, (IRQ_Fun)_isr_wrapper);
+	log_module_trace_init(NULL);
+	log_buffer_init();
+	log_gdma_init();
+	RamVectorTableUpdate(GDMA0_Channel9_VECTORn, (IRQ_Fun)_isr_wrapper);
 
-    si_flow_data_init();
+	si_flow_data_init();
 
-    ft_paras_apply();
+	ft_paras_apply();
 
-    pmu_apply_voltage_tune();
+	pmu_apply_voltage_tune();
 
-    bool aon_boot_done = AON_REG_READ_BITFIELD(AON_NS_REG0X_FW_GENERAL_NS, km4_aon_boot_done);
+	bool aon_boot_done = AON_REG_READ_BITFIELD(AON_NS_REG0X_FW_GENERAL_NS, km4_aon_boot_done);
 
-    if (!aon_boot_done)
-    {
-        pmu_power_on_sequence_restart();
-    }
-    else
-    {
-        si_flow_after_exit_low_power_mode();
+	if (!aon_boot_done) {
+		pmu_power_on_sequence_restart();
+	} else {
+		si_flow_after_exit_low_power_mode();
+		pmu_pm_exit();
+	}
 
-        pmu_pm_exit();
-    }
+	AON_REG_WRITE_BITFIELD(AON_NS_REG0X_FW_GENERAL_NS, km4_aon_boot_done, 1);
 
-    AON_REG_WRITE_BITFIELD(AON_NS_REG0X_FW_GENERAL_NS, km4_aon_boot_done, 1);
+	hal_setup_hardware();
 
-    hal_setup_hardware();
+	hal_setup_cpu();
 
-    hal_setup_cpu();
+	hw_aes_mutex_init();
 
-    hw_aes_mutex_init();
+	/* setlocale(LC_ALL, "C"); */
 
-    //setlocale(LC_ALL, "C");//cannot find <locale.h> in zephyr
+	set_up_32k_clk_src();/* use osif mem api */
 
-    set_up_32k_clk_src();//use os_mem api
+	set_lp_module_clk_info();
 
-    set_lp_module_clk_info();
+	platform_rtc_aon_init();
+	power_manager_master_init();
+	power_manager_slave_init();
+	platform_pm_init();
+	RamVectorTableUpdate(PF_RTC_VECTORn, (IRQ_Fun)_isr_wrapper);
+	RamVectorTableUpdate(NMI_VECTORn, (IRQ_Fun)z_arm_nmi);
 
-    platform_rtc_aon_init();
-    power_manager_master_init();
-    power_manager_slave_init();
-    platform_pm_init();
-    RamVectorTableUpdate(PF_RTC_VECTORn, (IRQ_Fun)_isr_wrapper);
-    RamVectorTableUpdate(NMI_VECTORn, (IRQ_Fun)z_arm_nmi);
+	init_osc_sdm_timer();/* use osif timer api */
 
-    init_osc_sdm_timer();//use os timer api
+	dvfs_init();
 
-    dvfs_init();
+	phy_hw_control_init(false);
+	phy_init(false);/* use osif timer api */
 
-    phy_hw_control_init(false);
-    phy_init(false);//use os timer api
+	thermal_tracking_timer_init();
 
-    thermal_tracking_timer_init();
-
-    if (flash_nor_get_exist_nsc(FLASH_NOR_IDX_SPIC0))
-    {
-        flash_nor_dump_main_info();
-        flash_nor_cmd_list_init_nsc();
-        flash_nor_init_bp_lv_nsc();
-    }
+	if (flash_nor_get_exist_nsc(FLASH_NOR_IDX_SPIC0)) {
+		flash_nor_dump_main_info();
+		flash_nor_cmd_list_init_nsc();
+		flash_nor_init_bp_lv_nsc();
+	}
 
 #if (CONFIG_TRUSTED_EXECUTION_NONSECURE == 1)
-    setup_non_secure_nvic();
+	setup_non_secure_nvic();
 #endif
 
-    return 0;
+	return 0;
 }
 
 static int rtk_task_init(void)
 {
-    extern const T_ROM_HEADER_FORMAT nonsecure_rom_header;
-    T_ROM_HEADER_FORMAT *stack_header = (T_ROM_HEADER_FORMAT *)STACK_ROM_ADDRESS;
+	BOOL_PATCH_FUNC lowerstack_entry;
+	T_ROM_HEADER_FORMAT *stack_header = (T_ROM_HEADER_FORMAT *)STACK_ROM_ADDRESS;
 
-    if (memcmp(stack_header->uuid, nonsecure_rom_header.uuid, UUID_SIZE) == 0)
-    {
-        BOOL_PATCH_FUNC lowerstack_entry = (BOOL_PATCH_FUNC)((uint32_t)stack_header->entry_ptr);
-        DBG_DIRECT("LOAD STACK ROM success!");
-        lowerstack_entry();
-        RamVectorTableUpdate(BTMAC_VECTORn, (IRQ_Fun)_isr_wrapper);
-        RamVectorTableUpdate(BTMAC_WRAP_AROUND_VECTORn, (IRQ_Fun)_isr_wrapper);
-    }
-    else
-    {
-        DBG_DIRECT("LOAD STACK ROM fail!");
-    }
+	if (memcmp(stack_header->uuid, nonsecure_rom_header.uuid, UUID_SIZE) == 0) {
+		lowerstack_entry = (BOOL_PATCH_FUNC)((uint32_t)stack_header->entry_ptr);
+		printk("Successfully loaded Realtek Lowerstack ROM!\n");
+		lowerstack_entry();
+		RamVectorTableUpdate(BTMAC_VECTORn, (IRQ_Fun)_isr_wrapper);
+		RamVectorTableUpdate(BTMAC_WRAP_AROUND_VECTORn, (IRQ_Fun)_isr_wrapper);
+	} else {
+		printk("Failed to load Realtek Lowerstack ROM!\n");
+	}
 
-    AON_REG_WRITE_BITFIELD(AON_NS_REG0X_FW_GENERAL_NS, km4_pon_boot_done, 1);
+	AON_REG_WRITE_BITFIELD(AON_NS_REG0X_FW_GENERAL_NS, km4_pon_boot_done, 1);
 
-    return 0;
+	return 0;
 }
 
 static int rtk_register_update(void)
 {
-    NVIC_SetPriority(SysTick_IRQn, 0xff);
-#ifdef CONFIG_SYSTICK_USE_EXTERNAL_CLOCK //use external clock
-    SysTick->CTRL &= ~SysTick_CTRL_CLKSOURCE_Msk;
+	NVIC_SetPriority(SysTick_IRQn, 0xff);
+#ifdef CONFIG_SYSTICK_USE_EXTERNAL_CLOCK
+	SysTick->CTRL &= ~SysTick_CTRL_CLKSOURCE_Msk;
 #endif
-    /* Unset this bit to avoid usagefault when dividing by zero.
-    If set this bit, function ll_iso_generate_cis_unframed_parameters_from_host_info (rom code) will trigger usage fault.
-    In freeRtos, this bit will not be set. */
-    SCB->CCR &= ~SCB_CCR_DIV_0_TRP_Msk;
-    return 0;
+/*
+ * Unset SCB_CCR_DIV_0_TRP bit to avoid usagefault when dividing by zero.
+ * If this bit is set, ll_iso_generate_cis_unframed_parameters_from_host_info()
+ * in rom will trigger usage fault.
+ * WARNING: In Freertos, this bit will not be set.
+ */
+	SCB->CCR &= ~SCB_CCR_DIV_0_TRP_Msk;
+	return 0;
 }
 
 SYS_INIT(rtk_platform_init, EARLY, 0);


### PR DESCRIPTION
secure_os_func_ptr_init which is implented in sys-patch will update to Freertos's svc vector, so we need update back to zephyr svc. This is a workaround. After the sys-patch updates the secure_os_func_ptr_init to differentiate between different OSes, this workaround will be removed.