### PR TITLE
soc: rtl87x2g: add image_base in header

### DIFF
--- a/soc/arm/realtek_bee/rtl87x2g/image_header.c
+++ b/soc/arm/realtek_bee/rtl87x2g/image_header.c
@@ -2,31 +2,31 @@
 #include <stdlib.h>
 #include <rom_uuid.h>
 #include <version.h>
+
 extern void z_arm_reset(void);
+
 const T_IMG_HEADER_FORMAT img_header __attribute__((section(".image_header"))) =
 {
-    .auth =
-    {
-        .image_mac = {[0 ... 15] = 0xFF},
-    },
-    .ctrl_header =
-    {
-        .ic_type = 0xF,
-        .secure_version = 0,
-        .ctrl_flag.xip = 1,
-        .ctrl_flag.enc = 0,
-        .ctrl_flag.load_when_boot = 0,
-        .ctrl_flag.enc_load = 0,
-        .ctrl_flag.not_obsolete = 1,
-        .image_id = IMG_MCUAPP,
-        .payload_len = 0x100,
-    },
-    .git_ver =
-    {
-        .ver_info.sub_version._version_major = KERNEL_VERSION_MAJOR,
-        .ver_info.sub_version._version_minor = KERNEL_VERSION_MINOR,
-        .ver_info.sub_version._version_revision = KERNEL_PATCHLEVEL,
-    },
-    .uuid = DEFINE_symboltable_uuid,
-    .exe_base = (unsigned int)z_arm_reset,
+	.auth = {
+		.image_mac = {[0 ... 15] = 0xFF},
+	},
+	.ctrl_header = {
+		.ic_type = 0xF,
+		.secure_version = 0,
+		.ctrl_flag.xip = 1,
+		.ctrl_flag.enc = 0,
+		.ctrl_flag.load_when_boot = 0,
+		.ctrl_flag.enc_load = 0,
+		.ctrl_flag.not_obsolete = 1,
+		.image_id = IMG_MCUAPP,
+		.payload_len = 0x100,
+	},
+	.git_ver = {
+		.ver_info.sub_version._version_major = KERNEL_VERSION_MAJOR,
+		.ver_info.sub_version._version_minor = KERNEL_VERSION_MINOR,
+		.ver_info.sub_version._version_revision = KERNEL_PATCHLEVEL,
+	},
+	.uuid = DEFINE_symboltable_uuid,
+	.exe_base = (unsigned int)z_arm_reset,
+	.image_base = CONFIG_FLASH_BASE_ADDRESS + CONFIG_FLASH_LOAD_OFFSET,
 };


### PR DESCRIPTION
When generating bin file with mp-header, rtk prepend header tool will use member "image_base". So we should assign a value to the image_base member variable, which is the start load address of the ROM region.

log verification：
```
Successfully loaded Realtek Lowerstack ROM!
image_base:402d000
*** Booting Zephyr OS build d257b61673d7 ***
Hello World! rtl8762gn_evb
```