### PR TITLE
soc: rtl87x2g: customize k_busy_wait api

### DIFF
--- a/soc/arm/realtek_bee/rtl87x2g/Kconfig.defconfig.series
+++ b/soc/arm/realtek_bee/rtl87x2g/Kconfig.defconfig.series
@@ -26,6 +26,9 @@ config SYS_CLOCK_TICKS_PER_SEC
 	default 100
     #10ms/1tick
 
+config ARCH_HAS_CUSTOM_BUSY_WAIT
+	default y
+
 config IDLE_STACK_SIZE
     default 1024
 

--- a/soc/arm/realtek_bee/rtl87x2g/soc.c
+++ b/soc/arm/realtek_bee/rtl87x2g/soc.c
@@ -188,6 +188,13 @@ static int rtk_register_update(void)
 	return 0;
 }
 
+#ifdef CONFIG_ARCH_HAS_CUSTOM_BUSY_WAIT
+void arch_busy_wait(uint32_t usec_to_wait)
+{
+	platform_delay_us(usec_to_wait);
+}
+#endif
+
 SYS_INIT(rtk_platform_init, EARLY, 0);
 SYS_INIT(rtk_register_update, PRE_KERNEL_2, 1);
 SYS_INIT(rtk_task_init, POST_KERNEL, 0);


### PR DESCRIPTION
The native k_busy_wait in Zephyr is implemented based on polling the systick counter for delays. In practice, on the KM4, this implementation results in inaccurate delays. Therefore, the ARCH_HAS_CUSTOM_BUSY_WAIT is enabled to use the platform_delay_us api from RTK to customize the implementation of k_busy_wait.