### PR TITLE
boards: rtl8762gn_evb: modify board yaml file

### DIFF
--- a/boards/arm/rtl8762gn_evb/rtl8762gn_evb.yaml
+++ b/boards/arm/rtl8762gn_evb/rtl8762gn_evb.yaml
@@ -1,15 +1,31 @@
 identifier: rtl8762gn_evb
-name: rtl8762gn_evb
+name: Realtek rtl8762gn evaluation board
 type: mcu
 arch: arm
-ram: 96
+ram: 320
 flash: 1024
 toolchain:
   - zephyr
   - gnuarmemb
   - xtools
 supported:
+  - adc
+  - gpio
+  - i2c
+  - counter
+  - spi
+  - watchdog
+  - nvs
+  - pwm
+  - uart
+  - ble
+  - usb_device
+  - dma
+  - kscan
+  - entropy
 testing:
   ignore_tags:
     - net
-    - bluetooth
+    - hwinfo
+    - ipc
+vendor: realtek


### PR DESCRIPTION
The 'supported' field in the rtl8762gn_evb.yaml file has not been filled in. The board-level YAML must be strictly completed according to the template, and each field needs to be filled in.