### PR TITLE
soc: rtl87x2g: change the header file in power.c

### DIFF
--- a/soc/arm/realtek_bee/rtl87x2g/power.c
+++ b/soc/arm/realtek_bee/rtl87x2g/power.c
@@ -15,7 +15,8 @@
 
 #include <cmsis_core.h>
 
-#include <pmu_manager.h>
+/* for platform_pm_register_callback_func_with_priority */
+#include <power_manager_unit_platform.h>
 #include <pm.h>
 #include <rtl_pinmux.h>
 #include <trace.h>


### PR DESCRIPTION
use power_manafer_unit_platform.h instead of pmu_manager.h, because pmu_manager.h will not be open-sourced.