### PR TITLE
pm: rtl87x2g: fix bugs for rtk dlps and zephyr timer

### DIFF
--- a/kernel/timeout.c
+++ b/kernel/timeout.c
@@ -338,7 +338,7 @@ void z_vrfy_sys_clock_tick_set(uint64_t tick)
 }
 #endif
 
-/* to realize the realtek power manager, we have to export these four APIs */
+/* To support RTK PM */
 struct _timeout *get_first_timeout(void)
 {
     sys_dnode_t *t = sys_dlist_peek_head(&timeout_list);
@@ -357,8 +357,23 @@ void sys_clock_announce_only_add_ticks(int32_t ticks)
 {
 	k_spinlock_key_t key = k_spin_lock(&timeout_lock);
 
-	announce_remaining += ticks;
 	curr_tick += ticks;
+
+	struct _timeout *t;
+
+	for (t = first();
+	     (t != NULL) && (t->dticks <= ticks);
+	     t = next(t)) {
+		int dt = t->dticks;
+
+		t->dticks = 0;
+
+		ticks -= dt;
+	}
+
+	if (t != NULL) {
+		t->dticks -= ticks;
+	}
 
 	k_spin_unlock(&timeout_lock, key);
 }
@@ -370,30 +385,11 @@ void sys_clock_announce_process_timeout(void)
 	struct _timeout *t;
 
 	for (t = first();
-	     (t != NULL) && (t->dticks <= announce_remaining);
+	     (t != NULL) && (t->dticks == 0);
 	     t = first()) {
-		int dt = t->dticks;
-
-		t->dticks = 0;
 		remove_timeout(t);
-
-		k_spin_unlock(&timeout_lock, key);
 		t->fn(t);
-		key = k_spin_lock(&timeout_lock);
-		announce_remaining -= dt;
 	}
-
-	if (t != NULL) {
-		t->dticks -= announce_remaining;
-	}
-
-	announce_remaining = 0;
-
-	sys_clock_set_timeout(next_timeout(), false);
 
 	k_spin_unlock(&timeout_lock, key);
-
-#ifdef CONFIG_TIMESLICING
-	z_time_slice();
-#endif
 }

--- a/kernel/timer.c
+++ b/kernel/timer.c
@@ -141,7 +141,15 @@ void z_impl_k_timer_start(struct k_timer *timer, k_timeout_t duration,
 {
 	SYS_PORT_TRACING_OBJ_FUNC(k_timer, start, timer, duration, period);
 
+	/* Acquire spinlock to ensure safety during concurrent calls to
+	 * k_timer_start for scheduling or rescheduling. This is necessary
+	 * since k_timer_start can be preempted, especially for the same
+	 * timer instance.
+	 */
+	k_spinlock_key_t key = k_spin_lock(&lock);
+
 	if (K_TIMEOUT_EQ(duration, K_FOREVER)) {
+		k_spin_unlock(&lock, key);
 		return;
 	}
 
@@ -168,6 +176,7 @@ void z_impl_k_timer_start(struct k_timer *timer, k_timeout_t duration,
 
 	z_add_timeout(&timer->timeout, z_timer_expiration_handler,
 		     duration);
+	k_spin_unlock(&lock, key);
 }
 
 #ifdef CONFIG_USERSPACE

--- a/soc/arm/realtek_bee/rtl87x2g/power.c
+++ b/soc/arm/realtek_bee/rtl87x2g/power.c
@@ -19,7 +19,6 @@
 #include <power_manager_unit_platform.h>
 #include <pm.h>
 #include <rtl_pinmux.h>
-#include <trace.h>
 
 #include <zephyr/logging/log.h>
 LOG_MODULE_DECLARE(soc, CONFIG_SOC_LOG_LEVEL);
@@ -27,86 +26,92 @@ LOG_MODULE_DECLARE(soc, CONFIG_SOC_LOG_LEVEL);
 volatile PINMUXStoreReg_Typedef Pinmux_StoreReg;
 extern void Pinmux_DLPSEnter(void *PeriReg, void *StoreBuf);
 extern void Pinmux_DLPSExit(void *PeriReg, void *StoreBuf);
+extern void NMI_Handler(void);
+extern void sys_clock_announce_process_timeout(void);
 
 volatile uint32_t CPU_StoreReg[6];
 volatile uint8_t CPU_StoreReg_IPR[96];
 volatile uint32_t Peripheral_StoreReg[2];
 static void CPU_DLPS_Enter(void)
 {
-    //NVIC store
-    uint32_t i;
+	/* NVIC store */
+	uint32_t i;
 
-    CPU_StoreReg[0] = NVIC->ISER[0];
-    CPU_StoreReg[1] = NVIC->ISER[1];
-    CPU_StoreReg[2] = NVIC->ISER[2];
+	CPU_StoreReg[0] = NVIC->ISER[0];
+	CPU_StoreReg[1] = NVIC->ISER[1];
+	CPU_StoreReg[2] = NVIC->ISER[2];
 
-    CPU_StoreReg[3] = NVIC->ISPR[0];
-    CPU_StoreReg[4] = NVIC->ISPR[1];
-    CPU_StoreReg[5] = NVIC->ISPR[2];
+	CPU_StoreReg[3] = NVIC->ISPR[0];
+	CPU_StoreReg[4] = NVIC->ISPR[1];
+	CPU_StoreReg[5] = NVIC->ISPR[2];
 
-    //     skip System_IRQn, WDG_IRQn, RXI300_IRQn, RXI300_SEC_IRQn,
-    //     Zigbee_IRQn which are handled in rom
-    const uint8_t *IPR_pt = (const uint8_t *)NVIC->IPR;
-    for (i = 5; i < 96; ++i)
-    {
-        CPU_StoreReg_IPR[i] = IPR_pt[i];
-    }
+	/* Skip System_IRQn, WDG_IRQn, RXI300_IRQn, RXI300_SEC_IRQn,
+	 * Zigbee_IRQn which are handled in rom.
+	 */
+	const uint8_t *IPR_pt = (const uint8_t *)NVIC->IPR;
 
-    // peripheral reg store
-    Peripheral_StoreReg[0] = SoC_VENDOR->u_008.REG_LOW_PRI_INT_MODE;
-    Peripheral_StoreReg[1] = SoC_VENDOR->u_00C.REG_LOW_PRI_INT_EN;
+	for (i = 5; i < 96; ++i) {
+		CPU_StoreReg_IPR[i] = IPR_pt[i];
+	}
 
-    return;
+	/* peripheral reg store */
+	Peripheral_StoreReg[0] = SoC_VENDOR->u_008.REG_LOW_PRI_INT_MODE;
+	Peripheral_StoreReg[1] = SoC_VENDOR->u_00C.REG_LOW_PRI_INT_EN;
+
+	return;
 }
 
 void CPU_DLPS_Exit(void)
 {
-    // peripheral reg restore
-    SoC_VENDOR->u_008.REG_LOW_PRI_INT_MODE = Peripheral_StoreReg[0];
-    SoC_VENDOR->u_00C.REG_LOW_PRI_INT_EN = Peripheral_StoreReg[1];
+	/* peripheral reg restore */
+	SoC_VENDOR->u_008.REG_LOW_PRI_INT_MODE = Peripheral_StoreReg[0];
+	SoC_VENDOR->u_00C.REG_LOW_PRI_INT_EN = Peripheral_StoreReg[1];
 
-    //NVIC restore
-    uint32_t i;
+	/* NVIC restore */
+	uint32_t i;
 
-    if ((CPU_StoreReg[0] & CPU_StoreReg[3]) || (CPU_StoreReg[1] & CPU_StoreReg[4]) ||
-        (CPU_StoreReg[2] & CPU_StoreReg[5]))
-    {
-        /* During enter and exit dlps, system will disable all interrupts. If any interrupt occurs during this period, this log will be printed.
-        Every bit of pending register corresponds to an interrupt. Please refer to IRQn_Type from System_IRQn to PF_RTC_IRQn.
-        For example:  "miss interrupt: pending register: 0x100, 0x0 , 0x0"
-        It means that RTC interrupt occur during dlps store and restore flow. But because all interrupts are masked, these interrupts are pending.
-        */
-        DBG_DIRECT("miss interrupt: pending register: 0x%x, 0x%x, 0x%x", CPU_StoreReg[3],
-                       CPU_StoreReg[4], CPU_StoreReg[5]);
-    }
+	/* During enter and exit dlps, system will disable all interrupts. If any interrupt
+	 * occurs during this period, this log will be printed.
+	 * Every bit of pending register corresponds to an interrupt. Please refer to IRQn_Type
+	 * from System_IRQn to PF_RTC_IRQn.
+	 * For example:  "miss interrupt: pending register: 0x100, 0x0 , 0x0"
+	 * It means that RTC interrupt occur during dlps store and restore flow.
+	 * But because all interrupts are masked, these interrupts are pending.
+	 */
+	if ((CPU_StoreReg[0] & CPU_StoreReg[3]) || (CPU_StoreReg[1] & CPU_StoreReg[4]) ||
+		(CPU_StoreReg[2] & CPU_StoreReg[5])) {
+		LOG_ERR("miss interrupt: pending register: 0x%x, 0x%x, 0x%x", CPU_StoreReg[3],
+					   CPU_StoreReg[4], CPU_StoreReg[5]);
+	}
 
-    //     skip System_IRQn, WDG_IRQn, RXI300_IRQn, RXI300_SEC_IRQn,
-    //     Zigbee_IRQn which are handled in rom
-    uint8_t *IPR_pt = (uint8_t *)NVIC->IPR;
-    for (i = 5; i < 96; ++i)
-    {
-        IPR_pt[i] = CPU_StoreReg_IPR[i];
-    }
+	/* Skip System_IRQn, WDG_IRQn, RXI300_IRQn, RXI300_SEC_IRQn,
+	 * Zigbee_IRQn which are handled in rom.
+	 */
+	uint8_t *IPR_pt = (uint8_t *)NVIC->IPR;
 
-    NVIC->ISER[0] = CPU_StoreReg[0];
-    NVIC->ISER[1] = CPU_StoreReg[1];
-    NVIC->ISER[2] = CPU_StoreReg[2];
+	for (i = 5; i < 96; ++i) {
+		IPR_pt[i] = CPU_StoreReg_IPR[i];
+	}
 
-    return;
+	NVIC->ISER[0] = CPU_StoreReg[0];
+	NVIC->ISER[1] = CPU_StoreReg[1];
+	NVIC->ISER[2] = CPU_StoreReg[2];
+
+	return;
 }
 
 void pm_state_set(enum pm_state state, uint8_t substate_id)
 {
-    ARG_UNUSED(state);
-    ARG_UNUSED(substate_id);
-    return;
+	ARG_UNUSED(state);
+	ARG_UNUSED(substate_id);
+	return;
 }
 
 void pm_state_exit_post_ops(enum pm_state state, uint8_t substate_id)
 {
-    ARG_UNUSED(state);
-    ARG_UNUSED(substate_id);
-    return;
+	ARG_UNUSED(state);
+	ARG_UNUSED(substate_id);
+	return;
 }
 
 #ifdef CONFIG_PM_DEVICE
@@ -118,16 +123,11 @@ static size_t num_susp_rtk;
 
 static int pm_suspend_devices_rtk(void)
 {
-	/* low stack do it instead */
-    // Pad_ClearAllWakeupINT();
-    // System_WakeupDebounceClear(0);
+	CPU_DLPS_Enter();
 
-    // NVIC_DisableIRQ(System_IRQn);
-    CPU_DLPS_Enter();
+	Pinmux_DLPSEnter(PINMUX, (void *)&Pinmux_StoreReg);
 
-    Pinmux_DLPSEnter(PINMUX, (void *)&Pinmux_StoreReg);
-
-    const struct device *devs;
+	const struct device *devs;
 	size_t devc;
 
 	devc = z_device_get_all_static(&devs);
@@ -137,14 +137,13 @@ static int pm_suspend_devices_rtk(void)
 	for (const struct device *dev = devs + devc - 1; dev >= devs; dev--) {
 		int ret;
 
-		/*
-		 * Ignore uninitialized devices, busy devices, wake up sources, and
+		/* Ignore uninitialized devices, busy devices, wake up sources, and
 		 * devices with runtime PM enabled.
 		 */
 		if (!device_is_ready(dev) || pm_device_is_busy(dev) ||
-		    pm_device_state_is_locked(dev) ||
-		    pm_device_wakeup_is_enabled(dev) ||
-		    pm_device_runtime_is_enabled(dev)) {
+			pm_device_state_is_locked(dev) ||
+			pm_device_wakeup_is_enabled(dev) ||
+			pm_device_runtime_is_enabled(dev)) {
 			continue;
 		}
 
@@ -160,8 +159,6 @@ static int pm_suspend_devices_rtk(void)
 			return ret;
 		}
 
-       // pm_device_state_lock(dev);//to bypass zephyr pm device system flow
-
 		TYPE_SECTION_START(pm_device_slots)[num_susp_rtk] = dev;
 		num_susp_rtk++;
 	}
@@ -172,20 +169,12 @@ static int pm_suspend_devices_rtk(void)
 void pm_resume_devices_rtk(void)
 {
 	Pinmux_DLPSExit(PINMUX, (void *)&Pinmux_StoreReg);
-    
-    for (int i = (num_susp_rtk - 1); i >= 0; i--) {
-		// pm_device_state_unlock(TYPE_SECTION_START(pm_device_slots)[i]);//correspond the pm_device_state_lock() in pm_suspend_devices_rtk
-        pm_device_action_run(TYPE_SECTION_START(pm_device_slots)[i],
-				    PM_DEVICE_ACTION_RESUME);
+	for (int i = (num_susp_rtk - 1); i >= 0; i--) {
+		pm_device_action_run(TYPE_SECTION_START(pm_device_slots)[i],
+					PM_DEVICE_ACTION_RESUME);
 	}
 
-    // NVIC_InitTypeDef nvic_init_struct = {0};
-    // nvic_init_struct.NVIC_IRQChannel         = System_IRQn;
-    // nvic_init_struct.NVIC_IRQChannelCmd      = (FunctionalState)ENABLE;
-    // nvic_init_struct.NVIC_IRQChannelPriority = 3;
-    // NVIC_Init(&nvic_init_struct); //Enable SYSTEM_ON Interrupt
-
-    CPU_DLPS_Exit();
+	CPU_DLPS_Exit();
 
 	num_susp_rtk = 0;
 }
@@ -204,54 +193,47 @@ struct k_work work_device_resume;
 
 void timeout_process_handler(struct k_work *item)
 {
-    extern void sys_clock_announce_process_timeout(void);
-    sys_clock_announce_process_timeout();
-    z_arm_int_exit();
-    return;
+	sys_clock_announce_process_timeout();
+	return;
 }
 
 void device_resume_handler(struct k_work *item)
 {
-    pm_resume_devices_rtk();
-    return;
+	pm_resume_devices_rtk();
+	return;
 }
 
 void submit_items_to_rtk_pm_workq(void)
 {
-    k_work_submit_to_queue(&rtk_pm_workq,&work_device_resume);
-    k_work_submit_to_queue(&rtk_pm_workq,&work_timeout_process);
-    return;
+	k_work_submit_to_queue(&rtk_pm_workq, &work_device_resume);
+	k_work_submit_to_queue(&rtk_pm_workq, &work_timeout_process);
+	return;
 }
 
 /* Initialize power system */
 static int rtl87x2g_power_init(void)
 {
-    int ret = 0;
+	int ret = 0;
 
-    bt_power_mode_set(BTPOWER_DEEP_SLEEP);
-    //bt_power_mode_set(BTPOWER_ACTIVE);
+	bt_power_mode_set(BTPOWER_DEEP_SLEEP);
+	power_mode_set(POWER_DLPS_MODE);
+	z_arm_nmi_set_handler(NMI_Handler);
+	k_work_queue_init(&rtk_pm_workq);
+	k_work_queue_start(&rtk_pm_workq, rtk_pm_workq_stack_area,
+				   K_THREAD_STACK_SIZEOF(rtk_pm_workq_stack_area),
+				   RTK_PM_WORKQ_PRIORITY, NULL);
+	k_work_init(&work_timeout_process, timeout_process_handler);
+	k_work_init(&work_device_resume, device_resume_handler);
+	platform_pm_register_callback_func_with_priority((void *)pm_suspend_devices_rtk,
+		PLATFORM_PM_STORE, 1);
+	/* do timeout function process and devices & nvic resume in
+	 * rtk_pm_workq thread via zephyr's workq mechanism.
+	 */
+	platform_pm_register_callback_func_with_priority((void *)submit_items_to_rtk_pm_workq,
+		PLATFORM_PM_RESTORE, 1);
 
-    power_mode_set(POWER_DLPS_MODE);
-    //power_mode_set(POWER_ACTIVE_MODE);
-
-    extern void NMI_Handler(void);
-    z_arm_nmi_set_handler(NMI_Handler);
-
-    k_work_queue_init(&rtk_pm_workq);
-
-    k_work_queue_start(&rtk_pm_workq, rtk_pm_workq_stack_area,
-                   K_THREAD_STACK_SIZEOF(rtk_pm_workq_stack_area), RTK_PM_WORKQ_PRIORITY,
-                   NULL);
-    
-    k_work_init(&work_timeout_process, timeout_process_handler);
-    k_work_init(&work_device_resume, device_resume_handler);
-
-    platform_pm_register_callback_func_with_priority((void *)pm_suspend_devices_rtk, PLATFORM_PM_STORE, 1);
-    
-/* do timeout function process and devices&nvic resume in rtk_pm_workq thread via zephyr's workq mechanism */
-    platform_pm_register_callback_func_with_priority((void *)submit_items_to_rtk_pm_workq, PLATFORM_PM_RESTORE,1);
-
-    return ret;
+	return ret;
 }
 
-SYS_INIT(rtl87x2g_power_init, POST_KERNEL, 1); //do it after lowerstack entry
+/* do it after lowerstack entry */
+SYS_INIT(rtl87x2g_power_init, POST_KERNEL, 1);


### PR DESCRIPTION
1. Resolved an issue where the exclude timer would execute more than
   once upon exiting DLPS.
2. fix zephyr timer bugs:
   https://github.com/zephyrproject-rtos/zephyr/pull/63491