### PR TITLE
drivers: adc: add bypass map for rtl8762gn_evb

### DIFF
--- a/drivers/adc/adc_rtl87x2g.c
+++ b/drivers/adc/adc_rtl87x2g.c
@@ -1,8 +1,8 @@
 /*
-* Copyright(c) 2020, Realtek Semiconductor Corporation.
-*
-* SPDX-License-Identifier: Apache-2.0
-*/
+ * Copyright(c) 2020, Realtek Semiconductor Corporation.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
 
 #define DT_DRV_COMPAT realtek_rtl87x2g_adc
 
@@ -27,313 +27,285 @@
 #include <zephyr/logging/log.h>
 LOG_MODULE_REGISTER(adc_rtl87x2g, CONFIG_ADC_LOG_LEVEL);
 
-struct adc_rtl87x2g_config
-{
-    uint32_t reg;
-    uint16_t clkid;
-    uint8_t channels;
-    const struct pinctrl_dev_config *pcfg;
-    uint8_t irq_num;
-    void (*irq_config_func)(const struct device *dev);
+struct adc_rtl87x2g_config {
+	uint32_t reg;
+	uint16_t clkid;
+	uint8_t channels;
+	const struct pinctrl_dev_config *pcfg;
+	uint8_t irq_num;
+	void (*irq_config_func)(const struct device *dev);
 };
 
-struct adc_rtl87x2g_data
-{
-    struct adc_context ctx;
-    const struct device *dev;
-    bool is_bypass_mode;
-    uint8_t seq_map;
-    int32_t *buffer;
-    int32_t *repeat_buffer;
+struct adc_rtl87x2g_data {
+	struct adc_context ctx;
+	const struct device *dev;
+	uint8_t is_bypass_mode;
+	uint8_t seq_map;
+	int32_t *buffer;
+	int32_t *repeat_buffer;
 #ifdef CONFIG_PM_DEVICE
-    ADCStoreReg_TypeDef store_buf;
+	ADCStoreReg_TypeDef store_buf;
 #endif
 };
 
-static int adc_rtl87x2g_start_read(const struct device *dev,
-                                   const struct adc_sequence *sequence)
+static int adc_rtl87x2g_start_read(const struct device *dev, const struct adc_sequence *sequence)
 {
-    struct adc_rtl87x2g_data *data = dev->data;
-    const struct adc_rtl87x2g_config *cfg = dev->config;
-    ADC_TypeDef *adc = (ADC_TypeDef *)cfg->reg;
+	struct adc_rtl87x2g_data *data = dev->data;
+	const struct adc_rtl87x2g_config *cfg = dev->config;
+	ADC_TypeDef *adc = (ADC_TypeDef *)cfg->reg;
 
-    if (sequence->resolution != 12U)
-    {
-        LOG_ERR("resolution is not valid");
-        return -ENOTSUP;
-    }
+	if (sequence->resolution != 12U) {
+		LOG_ERR("resolution is not valid");
+		return -ENOTSUP;
+	}
 
-    data->seq_map = sequence->channels;
+	data->seq_map = sequence->channels;
 
-    if (data->is_bypass_mode)
-    {
-        for (uint8_t i = 0; i < cfg->channels; i++)
-        {
-            if (sequence->channels & BIT(i))
-            {
-                ADC_BypassCmd(i, ENABLE);
-            }
-        }
-    }
-    ADC_BitMapConfig(adc, BIT(cfg->channels) - 1, DISABLE);
-    ADC_BitMapConfig(adc, sequence->channels, ENABLE);
+	for (uint8_t i = 0; i < cfg->channels; i++) {
+		if (sequence->channels & BIT(i)) {
+			if (data->is_bypass_mode & BIT(i)) {
+				ADC_BypassCmd(i, ENABLE);
+			} else {
+				ADC_BypassCmd(i, DISABLE);
+			}
+		}
+	}
 
-    data->buffer = sequence->buffer;
-    adc_context_start_read(&data->ctx, sequence);
+	ADC_BitMapConfig(adc, BIT(cfg->channels) - 1, DISABLE);
+	ADC_BitMapConfig(adc, sequence->channels, ENABLE);
 
-    return adc_context_wait_for_completion(&data->ctx);
+	data->buffer = sequence->buffer;
+	adc_context_start_read(&data->ctx, sequence);
+
+	return adc_context_wait_for_completion(&data->ctx);
 }
 
 static int adc_rtl87x2g_read(const struct device *dev, const struct adc_sequence *seq)
 {
-    struct adc_rtl87x2g_data *data = dev->data;
-    int error;
+	struct adc_rtl87x2g_data *data = dev->data;
+	int error;
 
-    adc_context_lock(&data->ctx, false, NULL);
-    error = adc_rtl87x2g_start_read(dev, seq);
-    adc_context_release(&data->ctx, error);
+	adc_context_lock(&data->ctx, false, NULL);
+	error = adc_rtl87x2g_start_read(dev, seq);
+	adc_context_release(&data->ctx, error);
 
-    return error;
+	return error;
 }
 
 #ifdef CONFIG_ADC_ASYNC
-static int adc_rtl87x2g_read_async(const struct device *dev,
-                                   const struct adc_sequence *sequence,
-                                   struct k_poll_signal *async)
+static int adc_rtl87x2g_read_async(const struct device *dev, const struct adc_sequence *sequence,
+				   struct k_poll_signal *async)
 {
-    struct adc_rtl87x2g_data *data = dev->data;
-    int error;
+	struct adc_rtl87x2g_data *data = dev->data;
+	int error;
 
-    adc_context_lock(&data->ctx, true, async);
-    error = adc_rtl87x2g_start_read(dev, sequence);
-    adc_context_release(&data->ctx, error);
+	adc_context_lock(&data->ctx, true, async);
+	error = adc_rtl87x2g_start_read(dev, sequence);
+	adc_context_release(&data->ctx, error);
 
-    return error;
-
+	return error;
 }
 #endif /* CONFIG_ADC_ASYNC */
 
 static int adc_rtl87x2g_channel_setup(const struct device *dev,
-                                      const struct adc_channel_cfg *chan_cfg)
+				      const struct adc_channel_cfg *chan_cfg)
 {
-    const struct adc_rtl87x2g_config *cfg = dev->config;
+	const struct adc_rtl87x2g_config *cfg = dev->config;
 
-    if (chan_cfg->gain != ADC_GAIN_1)
-    {
-        LOG_ERR("Gain is not valid");
-        return -ENOTSUP;
-    }
+	if (chan_cfg->gain != ADC_GAIN_1) {
+		LOG_ERR("Gain is not valid");
+		return -ENOTSUP;
+	}
 
-    if (chan_cfg->reference != ADC_REF_INTERNAL)
-    {
-        LOG_ERR("Reference is not valid");
-        return -ENOTSUP;
-    }
+	if (chan_cfg->reference != ADC_REF_INTERNAL) {
+		LOG_ERR("Reference is not valid");
+		return -ENOTSUP;
+	}
 
-    if (chan_cfg->acquisition_time != ADC_ACQ_TIME_DEFAULT)
-    {
-        LOG_ERR("Unsupported acquisition_time '%d'", chan_cfg->acquisition_time);
-        return -ENOTSUP;
-    }
+	if (chan_cfg->acquisition_time != ADC_ACQ_TIME_DEFAULT) {
+		LOG_ERR("Unsupported acquisition_time '%d'", chan_cfg->acquisition_time);
+		return -ENOTSUP;
+	}
 
-    if (chan_cfg->channel_id >= cfg->channels)
-    {
-        LOG_ERR("Invalid channel (%u)", chan_cfg->channel_id);
-        return -EINVAL;
-    }
+	if (chan_cfg->channel_id >= cfg->channels) {
+		LOG_ERR("Invalid channel (%u)", chan_cfg->channel_id);
+		return -EINVAL;
+	}
 
-    if (chan_cfg->differential)
-    {
-        LOG_ERR("Differential sampling not supported");
-        return -ENOTSUP;
-    }
+	if (chan_cfg->differential) {
+		LOG_ERR("Differential sampling not supported");
+		return -ENOTSUP;
+	}
 
-    return 0;
+	return 0;
 }
 
 static void adc_context_start_sampling(struct adc_context *ctx)
 {
-    struct adc_rtl87x2g_data *data = CONTAINER_OF(ctx, struct adc_rtl87x2g_data, ctx);
-    const struct device *dev = data->dev;
-    const struct adc_rtl87x2g_config *cfg = dev->config;
-    ADC_TypeDef *adc = (ADC_TypeDef *)cfg->reg;
+	struct adc_rtl87x2g_data *data = CONTAINER_OF(ctx, struct adc_rtl87x2g_data, ctx);
+	const struct device *dev = data->dev;
+	const struct adc_rtl87x2g_config *cfg = dev->config;
+	ADC_TypeDef *adc = (ADC_TypeDef *)cfg->reg;
 
-    data->repeat_buffer = data->buffer;
+	data->repeat_buffer = data->buffer;
 
-    ADC_INTConfig(adc, ADC_INT_ONE_SHOT_DONE, ENABLE);
-    ADC_Cmd(adc, ADC_ONE_SHOT_MODE, ENABLE);
+	ADC_INTConfig(adc, ADC_INT_ONE_SHOT_DONE, ENABLE);
+	ADC_Cmd(adc, ADC_ONE_SHOT_MODE, ENABLE);
 }
 
-static void adc_context_update_buffer_pointer(struct adc_context *ctx,
-                                              bool repeat_sampling)
+static void adc_context_update_buffer_pointer(struct adc_context *ctx, bool repeat_sampling)
 {
-    struct adc_rtl87x2g_data *data = CONTAINER_OF(ctx, struct adc_rtl87x2g_data, ctx);
+	struct adc_rtl87x2g_data *data = CONTAINER_OF(ctx, struct adc_rtl87x2g_data, ctx);
 
-    if (repeat_sampling)
-    {
-        data->buffer = data->repeat_buffer;
-    }
+	if (repeat_sampling) {
+		data->buffer = data->repeat_buffer;
+	}
 }
 
 static void adc_rtl87x2g_isr(const struct device *dev)
 {
-    struct adc_rtl87x2g_data *data = dev->data;
-    const struct adc_rtl87x2g_config *cfg = dev->config;
-    ADC_TypeDef *adc = (ADC_TypeDef *)cfg->reg;
-    uint16_t raw_data;
-    int32_t voltage;
-    ADC_ErrorStatus error_status = NO_ERROR;
+	struct adc_rtl87x2g_data *data = dev->data;
+	const struct adc_rtl87x2g_config *cfg = dev->config;
+	ADC_TypeDef *adc = (ADC_TypeDef *)cfg->reg;
+	uint16_t raw_data;
+	int32_t voltage;
+	ADC_ErrorStatus error_status = NO_ERROR;
 
-    if (ADC_GetINTStatus(adc, ADC_INT_ONE_SHOT_DONE))
-    {
-        for (uint32_t i = 0; i < cfg->channels; i++)
-        {
-            if (data->seq_map & BIT(i))
-            {
-                raw_data = (uint16_t)ADC_ReadRawData(adc, i);
-                if (data->is_bypass_mode)
-                {
-                    voltage = ADC_GetVoltage(BYPASS_SINGLE_MODE, raw_data, &error_status);
-                }
-                else
-                {
-                    voltage = ADC_GetVoltage(DIVIDE_SINGLE_MODE, raw_data, &error_status);
-                }
-                *data->buffer++ = voltage;
-            }
-        }
+	if (ADC_GetINTStatus(adc, ADC_INT_ONE_SHOT_DONE)) {
+		for (uint32_t i = 0; i < cfg->channels; i++) {
+			if (data->seq_map & BIT(i)) {
+				raw_data = (uint16_t)ADC_ReadRawData(adc, i);
+				if (data->is_bypass_mode & BIT(i)) {
+					voltage = ADC_GetVoltage(BYPASS_SINGLE_MODE, raw_data,
+								 &error_status);
+				} else {
+					voltage = ADC_GetVoltage(DIVIDE_SINGLE_MODE, raw_data,
+								 &error_status);
+				}
+				*data->buffer++ = voltage;
+			}
+		}
 
-        ADC_Cmd(adc, ADC_ONE_SHOT_MODE, DISABLE);
-        ADC_INTConfig(adc, ADC_INT_ONE_SHOT_DONE, DISABLE);
-        ADC_ClearINTPendingBit(adc, ADC_INT_ONE_SHOT_DONE);
-        adc_context_on_sampling_done(&data->ctx, dev);
-    }
+		ADC_Cmd(adc, ADC_ONE_SHOT_MODE, DISABLE);
+		ADC_INTConfig(adc, ADC_INT_ONE_SHOT_DONE, DISABLE);
+		ADC_ClearINTPendingBit(adc, ADC_INT_ONE_SHOT_DONE);
+		adc_context_on_sampling_done(&data->ctx, dev);
+	}
 }
 
 #ifdef CONFIG_PM_DEVICE
-static int adc_rtl87x2g_pm_action(const struct device *dev,
-                                  enum pm_device_action action)
+static int adc_rtl87x2g_pm_action(const struct device *dev, enum pm_device_action action)
 {
-    struct adc_rtl87x2g_data *data = dev->data;
-    const struct adc_rtl87x2g_config *cfg = dev->config;
-    ADC_TypeDef *adc = (ADC_TypeDef *)cfg->reg;
-    int err;
-    extern void ADC_DLPSEnter(void *PeriReg, void *StoreBuf);
-    extern void ADC_DLPSExit(void *PeriReg, void *StoreBuf);
+	struct adc_rtl87x2g_data *data = dev->data;
+	const struct adc_rtl87x2g_config *cfg = dev->config;
+	ADC_TypeDef *adc = (ADC_TypeDef *)cfg->reg;
+	int err;
 
-    switch (action)
-    {
-    case PM_DEVICE_ACTION_SUSPEND:
+	extern void ADC_DLPSEnter(void *PeriReg, void *StoreBuf);
+	extern void ADC_DLPSExit(void *PeriReg, void *StoreBuf);
 
-        ADC_DLPSEnter(adc, &data->store_buf);
+	switch (action) {
+	case PM_DEVICE_ACTION_SUSPEND:
 
-        /* Move pins to sleep state */
-        err = pinctrl_apply_state(cfg->pcfg, PINCTRL_STATE_SLEEP);
-        if ((err < 0) && (err != -ENOENT))
-        {
-            return err;
-        }
-        break;
-    case PM_DEVICE_ACTION_RESUME:
-        /* Set pins to active state */
-        err = pinctrl_apply_state(cfg->pcfg, PINCTRL_STATE_DEFAULT);
-        if (err < 0)
-        {
-            return err;
-        }
+		ADC_DLPSEnter(adc, &data->store_buf);
 
-        ADC_DLPSExit(adc, &data->store_buf);
+		/* Move pins to sleep state */
+		err = pinctrl_apply_state(cfg->pcfg, PINCTRL_STATE_SLEEP);
+		if ((err < 0) && (err != -ENOENT)) {
+			return err;
+		}
+		break;
+	case PM_DEVICE_ACTION_RESUME:
+		/* Set pins to active state */
+		err = pinctrl_apply_state(cfg->pcfg, PINCTRL_STATE_DEFAULT);
+		if (err < 0) {
+			return err;
+		}
 
-        break;
-    default:
-        return -ENOTSUP;
-    }
+		ADC_DLPSExit(adc, &data->store_buf);
 
-    return 0;
+		break;
+	default:
+		return -ENOTSUP;
+	}
+
+	return 0;
 }
 #endif /* CONFIG_PM_DEVICE */
 
-static const struct adc_driver_api adc_rtl87x2g_driver_api =
-{
-    .channel_setup = adc_rtl87x2g_channel_setup,
-    .read          = adc_rtl87x2g_read,
+static const struct adc_driver_api adc_rtl87x2g_driver_api = {
+	.channel_setup = adc_rtl87x2g_channel_setup,
+	.read = adc_rtl87x2g_read,
 #ifdef CONFIG_ADC_ASYNC
-    .read_async    = adc_rtl87x2g_read_async,
+	.read_async = adc_rtl87x2g_read_async,
 #endif /* CONFIG_ADC_ASYNC */
 };
 
 static int adc_rtl87x2g_init(const struct device *dev)
 {
-    struct adc_rtl87x2g_data *data = dev->data;
-    const struct adc_rtl87x2g_config *cfg = dev->config;
-    int ret;
+	struct adc_rtl87x2g_data *data = dev->data;
+	const struct adc_rtl87x2g_config *cfg = dev->config;
+	int ret;
 
-    data->dev = dev;
+	data->dev = dev;
 
-    ret = pinctrl_apply_state(cfg->pcfg, PINCTRL_STATE_DEFAULT);
-    if (ret < 0)
-    {
-        return ret;
-    }
+	ret = pinctrl_apply_state(cfg->pcfg, PINCTRL_STATE_DEFAULT);
+	if (ret < 0) {
+		return ret;
+	}
 
-    (void)clock_control_on(RTL87X2G_CLOCK_CONTROLLER,
-                           (clock_control_subsys_t)&cfg->clkid);
+	(void)clock_control_on(RTL87X2G_CLOCK_CONTROLLER, (clock_control_subsys_t)&cfg->clkid);
 
-    ret = pinctrl_apply_state(cfg->pcfg, PINCTRL_STATE_DEFAULT);
-    if (ret < 0)
-    {
-        return ret;
-    }
+	ret = pinctrl_apply_state(cfg->pcfg, PINCTRL_STATE_DEFAULT);
+	if (ret < 0) {
+		return ret;
+	}
 
-    ADC_CalibrationInit();
-    
-    ADC_InitTypeDef adc_init_struct;
-    ADC_StructInit(&adc_init_struct);
-    adc_init_struct.ADC_DataAvgEn        = DISABLE;
-    adc_init_struct.ADC_PowerAlwaysOnEn  = ENABLE;
-    adc_init_struct.ADC_SampleTime       = 19;
-    for (uint32_t i = 0; i < cfg->channels; i++)
-    {
-        adc_init_struct.ADC_SchIndex[i] = EXT_SINGLE_ENDED(i);
-    }
-    ADC_Init(ADC, &adc_init_struct);
+	ADC_CalibrationInit();
 
-    cfg->irq_config_func(dev);
+	ADC_InitTypeDef adc_init_struct;
 
-    adc_context_unlock_unconditionally(&data->ctx);
+	ADC_StructInit(&adc_init_struct);
+	adc_init_struct.ADC_DataAvgEn = DISABLE;
+	adc_init_struct.ADC_PowerAlwaysOnEn = ENABLE;
+	adc_init_struct.ADC_SampleTime = 19;
+	for (uint32_t i = 0; i < cfg->channels; i++) {
+		adc_init_struct.ADC_SchIndex[i] = EXT_SINGLE_ENDED(i);
+	}
+	ADC_Init(ADC, &adc_init_struct);
 
-    return 0;
+	cfg->irq_config_func(dev);
+
+	adc_context_unlock_unconditionally(&data->ctx);
+
+	return 0;
 }
 
-#define RTL87X2G_ADC_INIT(index)                                    \
-    PINCTRL_DT_INST_DEFINE(index);                              \
-    static void adc_rtl87x2g_irq_config_func(const struct device *dev)   \
-    {                                   \
-        IRQ_CONNECT(DT_INST_IRQN(index),                \
-                    DT_INST_IRQ(index, priority),               \
-                    adc_rtl87x2g_isr, DEVICE_DT_INST_GET(index),       \
-                    0);                         \
-        irq_enable(DT_INST_IRQN(index));                \
-    }             \
-    static struct adc_rtl87x2g_data adc_rtl87x2g_data_##index = {                   \
-        ADC_CONTEXT_INIT_TIMER(adc_rtl87x2g_data_##index, ctx),                 \
-        ADC_CONTEXT_INIT_LOCK(adc_rtl87x2g_data_##index, ctx),                  \
-        ADC_CONTEXT_INIT_SYNC(adc_rtl87x2g_data_##index, ctx),                  \
-        .is_bypass_mode = DT_INST_PROP(index, is_bypass_mode),                   \
-    };                                          \
-    const static struct adc_rtl87x2g_config adc_rtl87x2g_config_##index = {             \
-        .reg = DT_INST_REG_ADDR(index),                         \
-        .clkid = DT_INST_CLOCKS_CELL(index, id),                        \
-        .channels = DT_INST_PROP(index, channels),                      \
-        .pcfg = PINCTRL_DT_INST_DEV_CONFIG_GET(index),                  \
-        .irq_num = DT_INST_IRQN(index),                         \
-        .irq_config_func = adc_rtl87x2g_irq_config_func,                   \
-    };                                          \
-     PM_DEVICE_DT_INST_DEFINE(index, adc_rtl87x2g_pm_action);    \
-     DEVICE_DT_INST_DEFINE(index,                                \
-                          &adc_rtl87x2g_init, PM_DEVICE_DT_INST_GET(index),                     \
-                          &adc_rtl87x2g_data_##index, &adc_rtl87x2g_config_##index,             \
-                          POST_KERNEL, CONFIG_ADC_INIT_PRIORITY,                \
-                          &adc_rtl87x2g_driver_api);                        \
+#define RTL87X2G_ADC_INIT(index)                                                                   \
+	PINCTRL_DT_INST_DEFINE(index);                                                             \
+	static void adc_rtl87x2g_irq_config_func(const struct device *dev)                         \
+	{                                                                                          \
+		IRQ_CONNECT(DT_INST_IRQN(index), DT_INST_IRQ(index, priority), adc_rtl87x2g_isr,   \
+			    DEVICE_DT_INST_GET(index), 0);                                         \
+		irq_enable(DT_INST_IRQN(index));                                                   \
+	}                                                                                          \
+	static struct adc_rtl87x2g_data adc_rtl87x2g_data_##index = {                              \
+		ADC_CONTEXT_INIT_TIMER(adc_rtl87x2g_data_##index, ctx),                            \
+		ADC_CONTEXT_INIT_LOCK(adc_rtl87x2g_data_##index, ctx),                             \
+		ADC_CONTEXT_INIT_SYNC(adc_rtl87x2g_data_##index, ctx),                             \
+		.is_bypass_mode = DT_INST_PROP_OR(index, is_bypass_mode, 0),                       \
+	};                                                                                         \
+	const static struct adc_rtl87x2g_config adc_rtl87x2g_config_##index = {                    \
+		.reg = DT_INST_REG_ADDR(index),                                                    \
+		.clkid = DT_INST_CLOCKS_CELL(index, id),                                           \
+		.channels = DT_INST_PROP(index, channels),                                         \
+		.pcfg = PINCTRL_DT_INST_DEV_CONFIG_GET(index),                                     \
+		.irq_num = DT_INST_IRQN(index),                                                    \
+		.irq_config_func = adc_rtl87x2g_irq_config_func,                                   \
+	};                                                                                         \
+	PM_DEVICE_DT_INST_DEFINE(index, adc_rtl87x2g_pm_action);                                   \
+	DEVICE_DT_INST_DEFINE(index, &adc_rtl87x2g_init, PM_DEVICE_DT_INST_GET(index),             \
+			      &adc_rtl87x2g_data_##index, &adc_rtl87x2g_config_##index,            \
+			      POST_KERNEL, CONFIG_ADC_INIT_PRIORITY, &adc_rtl87x2g_driver_api);
 
 DT_INST_FOREACH_STATUS_OKAY(RTL87X2G_ADC_INIT)

--- a/dts/bindings/adc/realtek,rtl87x2g-adc.yaml
+++ b/dts/bindings/adc/realtek,rtl87x2g-adc.yaml
@@ -69,9 +69,12 @@ properties:
     required: true
 
   is-bypass-mode:
-    type: boolean
+    type: int
+    default: 0
     description: |
-      Config adc channels as bypass mode or divide mode.
+      This is a channel map to configure bypass/divide mode for each adc channel.
+      For example, configure 0x05 means channel0 and channel2 are configured as bypass mode,
+      and other channels are configured as divide mode by default.
       In "divide mode" the ADC range is 0 to 3.3V.
       In "bypass mode" the ADC range is 0 to 0.9V.
 


### PR DESCRIPTION
Change is-bypass-mode from boolean to int for users to configure bypass/divide mode for each adc channel.