### PR TITLE
pm: rtl87x2g: Enhance RTK power management flow

### DIFF
--- a/drivers/timer/cortex_m_systick.c
+++ b/drivers/timer/cortex_m_systick.c
@@ -298,6 +298,13 @@ uint64_t sys_clock_cycle_get_64(void)
 }
 #endif
 
+#if CONFIG_SOC_FAMILY_REALTEK_BEE
+void sys_clock_only_add_cycle_count(int32_t ticks)
+{
+	cycle_count += ticks * last_load;
+}
+#endif
+
 void sys_clock_idle_exit(void)
 {
 	if (last_load == TIMER_STOPPED) {


### PR DESCRIPTION
1. Implemented a pended_tick mechanism to ensure the first timeout callback after exiting DLPS is processed in the rtk_pm_workq thread, following device resumption.
2. Restored the cycle_count value upon exiting DLPS to maintain consistency.