### PR TITLE
bee: remove the duplicate sys_clock_only_add_cycle_count

### DIFF
--- a/drivers/timer/cortex_m_systick.c
+++ b/drivers/timer/cortex_m_systick.c
@@ -432,13 +432,6 @@ void sys_clock_idle_exit(void)
 	}
 }
 
-#ifdef CONFIG_SOC_SERIES_RTL87X2G
-void sys_clock_only_add_cycle_count(int32_t ticks)
-{
-	cycle_count += ticks * last_load;
-}
-#endif
-
 void sys_clock_disable(void)
 {
 	SysTick->CTRL &= ~SysTick_CTRL_ENABLE_Msk;


### PR DESCRIPTION
remove the duplicate sys_clock_only_add_cycle_count in cortex_m_systick.c