### PR TITLE
drivers: correct driver pm flow for rtl87x2g

### DIFF
--- a/drivers/gpio/gpio_rtl87x2g.c
+++ b/drivers/gpio/gpio_rtl87x2g.c
@@ -102,16 +102,15 @@ static int gpio_rtl87x2g_gpio2pad(uint8_t port_num, uint32_t pin)
 	return -EIO;
 }
 
-
 #ifdef CONFIG_PM_DEVICE
-static int gpio_rtl87x2g_pm_pad_list_insert(struct pm_pad_node *head,
-	struct pm_pad_node *array, uint8_t pad_num, uint8_t gpio_num);
-static void gpio_rtl87x2g_pm_pad_list_remove(struct pm_pad_node *head,
-	struct pm_pad_node *array, uint8_t pad_num, uint8_t gpio_num);
+static int gpio_rtl87x2g_pm_pad_list_insert(struct pm_pad_node *head, struct pm_pad_node *array,
+					    uint8_t pad_num, uint8_t gpio_num);
+static void gpio_rtl87x2g_pm_pad_list_remove(struct pm_pad_node *head, struct pm_pad_node *array,
+					     uint8_t pad_num, uint8_t gpio_num);
 #endif
 
 static int gpio_rtl87x2g_pin_configure(const struct device *port, gpio_pin_t pin,
-				gpio_flags_t flags)
+				       gpio_flags_t flags)
 {
 	LOG_DBG("port=%s, pin=%d, flags=0x%x, line%d\n", port->name, pin, flags, __LINE__);
 
@@ -123,8 +122,8 @@ static int gpio_rtl87x2g_pin_configure(const struct device *port, gpio_pin_t pin
 	int pad_pin = gpio_rtl87x2g_gpio2pad(port_num, pin);
 	PADPullMode_TypeDef pull_config;
 	GPIO_InitTypeDef gpio_init_struct;
-	uint8_t debounce_ms = (flags & RTL87X2G_GPIO_INPUT_DEBOUNCE_MS_MASK)
-		>> RTL87X2G_GPIO_INPUT_DEBOUNCE_MS_POS;
+	uint8_t debounce_ms = (flags & RTL87X2G_GPIO_INPUT_DEBOUNCE_MS_MASK) >>
+			      RTL87X2G_GPIO_INPUT_DEBOUNCE_MS_POS;
 	int ret = 0;
 
 	__ASSERT(pad_pin >= 0, "gpio port or pin error");
@@ -137,7 +136,7 @@ static int gpio_rtl87x2g_pin_configure(const struct device *port, gpio_pin_t pin
 	if (flags == GPIO_DISCONNECTED) {
 		Pinmux_Deinit(pad_pin);
 		Pad_Config(pad_pin, PAD_SW_MODE, PAD_NOT_PWRON, PAD_PULL_NONE, PAD_OUT_DISABLE,
-					PAD_OUT_HIGH);
+			   PAD_OUT_HIGH);
 	} else {
 		/* config pad pull status */
 
@@ -166,16 +165,18 @@ static int gpio_rtl87x2g_pin_configure(const struct device *port, gpio_pin_t pin
 
 		gpio_init_struct.GPIO_Pin = gpio_bit;
 		gpio_init_struct.GPIO_Mode = flags & GPIO_OUTPUT ? GPIO_Mode_OUT : GPIO_Mode_IN;
-		gpio_init_struct.GPIO_OutPutMode = flags & GPIO_OPEN_DRAIN ?
-			GPIO_OUTPUT_OPENDRAIN : GPIO_OUTPUT_PUSHPULL;
+		gpio_init_struct.GPIO_OutPutMode =
+			flags & GPIO_OPEN_DRAIN ? GPIO_OUTPUT_OPENDRAIN : GPIO_OUTPUT_PUSHPULL;
 		gpio_init_struct.GPIO_ITCmd = flags & GPIO_INT_ENABLE ? ENABLE : DISABLE;
-		gpio_init_struct.GPIO_ITTrigger = flags & GPIO_INT_LEVELS_LOGICAL ?
-			GPIO_INT_Trigger_LEVEL : GPIO_INT_Trigger_EDGE;
-		gpio_init_struct.GPIO_ITPolarity = flags & GPIO_INT_LOW_0 ?
-			GPIO_INT_POLARITY_ACTIVE_LOW : GPIO_INT_POLARITY_ACTIVE_HIGH;
-		Pad_Config(pad_pin, PAD_PINMUX_MODE,  PAD_IS_PWRON,  pull_config,
-			flags & GPIO_OUTPUT ? PAD_OUT_ENABLE : PAD_OUT_DISABLE,
-			flags & GPIO_OUTPUT_INIT_HIGH ? PAD_OUT_HIGH : PAD_OUT_LOW);
+		gpio_init_struct.GPIO_ITTrigger = flags & GPIO_INT_LEVELS_LOGICAL
+							  ? GPIO_INT_Trigger_LEVEL
+							  : GPIO_INT_Trigger_EDGE;
+		gpio_init_struct.GPIO_ITPolarity = flags & GPIO_INT_LOW_0
+							   ? GPIO_INT_POLARITY_ACTIVE_LOW
+							   : GPIO_INT_POLARITY_ACTIVE_HIGH;
+		Pad_Config(pad_pin, PAD_PINMUX_MODE, PAD_IS_PWRON, pull_config,
+			   flags & GPIO_OUTPUT ? PAD_OUT_ENABLE : PAD_OUT_DISABLE,
+			   flags & GPIO_OUTPUT_INIT_HIGH ? PAD_OUT_HIGH : PAD_OUT_LOW);
 		Pinmux_Config(pad_pin, DWGPIO);
 
 		switch (flags & (GPIO_OUTPUT | GPIO_OUTPUT_INIT_HIGH | GPIO_OUTPUT_INIT_LOW)) {
@@ -205,19 +206,19 @@ static int gpio_rtl87x2g_pin_configure(const struct device *port, gpio_pin_t pin
 
 #ifdef CONFIG_PM_DEVICE
 	if (flags & GPIO_OUTPUT) {
-		gpio_rtl87x2g_pm_pad_list_remove(data->list.wakeup_head, data->list.array,
-				pad_pin, pin);
+		gpio_rtl87x2g_pm_pad_list_remove(data->list.wakeup_head, data->list.array, pad_pin,
+						 pin);
 		ret = gpio_rtl87x2g_pm_pad_list_insert(data->list.output_head, data->list.array,
-				pad_pin, pin);
+						       pad_pin, pin);
 		if (ret) {
 			LOG_ERR("Failed to insert gpio pm pad list");
 			return ret;
 		}
 	} else if ((flags & GPIO_INPUT) && (flags & RTL87X2G_GPIO_INPUT_PM_WAKEUP)) {
-		gpio_rtl87x2g_pm_pad_list_remove(data->list.output_head, data->list.array,
-				pad_pin, pin);
+		gpio_rtl87x2g_pm_pad_list_remove(data->list.output_head, data->list.array, pad_pin,
+						 pin);
 		ret = gpio_rtl87x2g_pm_pad_list_insert(data->list.wakeup_head, data->list.array,
-				pad_pin, pin);
+						       pad_pin, pin);
 		if (ret) {
 			LOG_ERR("Failed to insert gpio pm pad list");
 			return ret;
@@ -229,8 +230,7 @@ static int gpio_rtl87x2g_pin_configure(const struct device *port, gpio_pin_t pin
 	return 0;
 }
 
-static int gpio_rtl87x2g_port_get_raw(const struct device *port,
-				gpio_port_value_t *value)
+static int gpio_rtl87x2g_port_get_raw(const struct device *port, gpio_port_value_t *value)
 {
 	const struct gpio_rtl87x2g_config *config = port->config;
 	GPIO_TypeDef *port_base = config->port_base;
@@ -240,9 +240,8 @@ static int gpio_rtl87x2g_port_get_raw(const struct device *port,
 	return 0;
 }
 
-static int gpio_rtl87x2g_port_set_masked_raw(const struct device *port,
-				gpio_port_pins_t mask,
-				gpio_port_value_t value)
+static int gpio_rtl87x2g_port_set_masked_raw(const struct device *port, gpio_port_pins_t mask,
+					     gpio_port_value_t value)
 {
 	const struct gpio_rtl87x2g_config *config = port->config;
 	GPIO_TypeDef *port_base = config->port_base;
@@ -254,8 +253,7 @@ static int gpio_rtl87x2g_port_set_masked_raw(const struct device *port,
 	return 0;
 }
 
-static int gpio_rtl87x2g_port_set_bits_raw(const struct device *port,
-				gpio_port_pins_t pins)
+static int gpio_rtl87x2g_port_set_bits_raw(const struct device *port, gpio_port_pins_t pins)
 {
 	const struct gpio_rtl87x2g_config *config = port->config;
 	GPIO_TypeDef *port_base = config->port_base;
@@ -265,8 +263,7 @@ static int gpio_rtl87x2g_port_set_bits_raw(const struct device *port,
 	return 0;
 }
 
-static int gpio_rtl87x2g_port_clear_bits_raw(const struct device *port,
-				gpio_port_pins_t pins)
+static int gpio_rtl87x2g_port_clear_bits_raw(const struct device *port, gpio_port_pins_t pins)
 {
 	const struct gpio_rtl87x2g_config *config = port->config;
 	GPIO_TypeDef *port_base = config->port_base;
@@ -276,27 +273,25 @@ static int gpio_rtl87x2g_port_clear_bits_raw(const struct device *port,
 	return 0;
 }
 
-static int gpio_rtl87x2g_port_toggle_bits(const struct device *port,
-				gpio_port_pins_t pins)
+static int gpio_rtl87x2g_port_toggle_bits(const struct device *port, gpio_port_pins_t pins)
 {
 	const struct gpio_rtl87x2g_config *config = port->config;
 	GPIO_TypeDef *port_base = config->port_base;
-	gpio_port_pins_t pins_value = GPIO_ReadInputData(port_base);
+	uint32_t pins_value = GPIO_ReadInputData(port_base);
 
 	pins_value = (pins_value | pins) & ~(pins_value & pins);
 	GPIO_Write(port_base, pins_value);
-	LOG_DBG("port=%s, pin=0x%x, pins_value=0x%x, line%d\n",
-			port->name, pins, pins_value, __LINE__);
+	LOG_DBG("port=%s, pin=0x%x, pins_value=0x%x, line%d\n", port->name, pins, pins_value,
+		__LINE__);
 
 	return 0;
 }
 
-static int gpio_rtl87x2g_pin_interrupt_configure(const struct device *port,
-				gpio_pin_t pin,
-				enum gpio_int_mode mode, enum gpio_int_trig trig)
+static int gpio_rtl87x2g_pin_interrupt_configure(const struct device *port, gpio_pin_t pin,
+						 enum gpio_int_mode mode, enum gpio_int_trig trig)
 {
-	LOG_DBG("port=%s, pin=%d, mode=0x%x, trig=0x%x, line%d\n",
-			port->name, pin, mode, trig, __LINE__);
+	LOG_DBG("port=%s, pin=%d, mode=0x%x, trig=0x%x, line%d\n", port->name, pin, mode, trig,
+		__LINE__);
 	const struct gpio_rtl87x2g_config *config = port->config;
 	struct gpio_rtl87x2g_data *data = port->data;
 	GPIO_TypeDef *port_base = config->port_base;
@@ -367,9 +362,8 @@ static int gpio_rtl87x2g_pin_interrupt_configure(const struct device *port,
 	return 0;
 }
 
-static int gpio_rtl87x2g_manage_callback(const struct device *port,
-				struct gpio_callback *cb,
-				bool set)
+static int gpio_rtl87x2g_manage_callback(const struct device *port, struct gpio_callback *cb,
+					 bool set)
 {
 	struct gpio_rtl87x2g_data *port_data = port->data;
 
@@ -386,7 +380,7 @@ static uint32_t gpio_rtl87x2g_get_pending_int(const struct device *dev)
 
 #ifdef CONFIG_GPIO_GET_DIRECTION
 int gpio_rtl87x2g_port_get_direction(const struct device *port, gpio_port_pins_t map,
-			gpio_port_pins_t *inputs, gpio_port_pins_t *outputs)
+				     gpio_port_pins_t *inputs, gpio_port_pins_t *outputs)
 {
 	const struct gpio_rtl87x2g_config *config = port->config;
 	GPIO_TypeDef *port_base = config->port_base;
@@ -418,8 +412,8 @@ static int gpio_rtl87x2g_pm_pad_list_init(struct pm_pad_node_list *list)
 	return 0;
 }
 
-static int gpio_rtl87x2g_pm_pad_list_insert(struct pm_pad_node *head,
-	struct pm_pad_node *array, uint8_t pad_num, uint8_t gpio_num)
+static int gpio_rtl87x2g_pm_pad_list_insert(struct pm_pad_node *head, struct pm_pad_node *array,
+					    uint8_t pad_num, uint8_t gpio_num)
 {
 	struct pm_pad_node *new_node;
 	struct pm_pad_node *cur_node = head;
@@ -427,7 +421,7 @@ static int gpio_rtl87x2g_pm_pad_list_insert(struct pm_pad_node *head,
 	/* Search from head to tail */
 	while (cur_node->next_gpio_num != 0xff) {
 		if (cur_node->pad_num > pad_num &&
-			array[cur_node->next_gpio_num].pad_num < pad_num) {
+		    array[cur_node->next_gpio_num].pad_num < pad_num) {
 			/* Insert the node */
 			new_node = &(array[gpio_num]);
 			new_node->pad_num = pad_num;
@@ -455,8 +449,8 @@ static int gpio_rtl87x2g_pm_pad_list_insert(struct pm_pad_node *head,
 	return 0;
 }
 
-static void gpio_rtl87x2g_pm_pad_list_remove(struct pm_pad_node *head,
-	struct pm_pad_node *array, uint8_t pad_num, uint8_t gpio_num)
+static void gpio_rtl87x2g_pm_pad_list_remove(struct pm_pad_node *head, struct pm_pad_node *array,
+					     uint8_t pad_num, uint8_t gpio_num)
 {
 	struct pm_pad_node *cur_node = head;
 
@@ -464,7 +458,7 @@ static void gpio_rtl87x2g_pm_pad_list_remove(struct pm_pad_node *head,
 		if (array[cur_node->next_gpio_num].pad_num == pad_num) {
 			if (array[cur_node->next_gpio_num].next_gpio_num != 0xff) {
 				cur_node->next_gpio_num =
-				array[cur_node->next_gpio_num].next_gpio_num;
+					array[cur_node->next_gpio_num].next_gpio_num;
 			} else {
 				cur_node->next_gpio_num = 0xff;
 			}
@@ -480,8 +474,7 @@ static void gpio_rtl87x2g_pm_pad_list_remove(struct pm_pad_node *head,
 	return;
 }
 
-static int gpio_rtl87x2g_pm_action(const struct device *port,
-				enum pm_device_action action)
+static int gpio_rtl87x2g_pm_action(const struct device *port, enum pm_device_action action)
 {
 	const struct gpio_rtl87x2g_config *config = port->config;
 	struct gpio_rtl87x2g_data *data = port->data;
@@ -497,14 +490,14 @@ static int gpio_rtl87x2g_pm_action(const struct device *port,
 	case PM_DEVICE_ACTION_SUSPEND:
 		while (cur_output_pad_node->next_gpio_num != 0xff) {
 			Pad_SetOutputLevel(
-			pm_pad_node_array[cur_output_pad_node->next_gpio_num].pad_num,
-			GPIO_ReadOutputDataBit(port_base,
-			BIT(cur_output_pad_node->next_gpio_num)));
+				pm_pad_node_array[cur_output_pad_node->next_gpio_num].pad_num,
+				GPIO_ReadOutputDataBit(port_base,
+						       BIT(cur_output_pad_node->next_gpio_num)));
 			Pad_SetControlMode(
-			pm_pad_node_array[cur_output_pad_node->next_gpio_num].pad_num,
-			PAD_SW_MODE);
+				pm_pad_node_array[cur_output_pad_node->next_gpio_num].pad_num,
+				PAD_SW_MODE);
 			cur_output_pad_node =
-			&(pm_pad_node_array[cur_output_pad_node->next_gpio_num]);
+				&(pm_pad_node_array[cur_output_pad_node->next_gpio_num]);
 		}
 
 		while (cur_wakeup_pad_node->next_gpio_num != 0xff) {
@@ -514,21 +507,23 @@ static int gpio_rtl87x2g_pm_action(const struct device *port,
 			 */
 			if (port_base->GPIO_INT_EN & BIT(cur_wakeup_pad_node->next_gpio_num)) {
 				extern uint32_t GPIO_SwapDebPinBit(GPIO_TypeDef *GPIOx,
-					uint32_t GPIO_Pin);
-				uint32_t GPIO_Pin_Swap = GPIO_SwapDebPinBit(port_base,
-					BIT(cur_wakeup_pad_node->next_gpio_num));
+								   uint32_t GPIO_Pin);
+				uint32_t GPIO_Pin_Swap = GPIO_SwapDebPinBit(
+					port_base, BIT(cur_wakeup_pad_node->next_gpio_num));
 				bool high_trigger = port_base->GPIO_EXT_DEB_POL_CTL & GPIO_Pin_Swap;
 
 				Pad_SetControlMode(
-				pm_pad_node_array[cur_wakeup_pad_node->next_gpio_num].pad_num,
-				PAD_SW_MODE);
+					pm_pad_node_array[cur_wakeup_pad_node->next_gpio_num]
+						.pad_num,
+					PAD_SW_MODE);
 				System_WakeUpPinEnable(
-				pm_pad_node_array[cur_wakeup_pad_node->next_gpio_num].pad_num,
-				high_trigger ?
-				PAD_WAKEUP_POL_HIGH : PAD_WAKEUP_POL_LOW, PAD_WAKEUP_DEB_DISABLE);
+					pm_pad_node_array[cur_wakeup_pad_node->next_gpio_num]
+						.pad_num,
+					high_trigger ? PAD_WAKEUP_POL_HIGH : PAD_WAKEUP_POL_LOW,
+					PAD_WAKEUP_DEB_DISABLE);
 			}
 			cur_wakeup_pad_node =
-			&(pm_pad_node_array[cur_wakeup_pad_node->next_gpio_num]);
+				&(pm_pad_node_array[cur_wakeup_pad_node->next_gpio_num]);
 		}
 
 		GPIO_DLPSEnter(port_base, &data->store_buf);
@@ -537,21 +532,27 @@ static int gpio_rtl87x2g_pm_action(const struct device *port,
 	case PM_DEVICE_ACTION_RESUME:
 
 		while (cur_output_pad_node->next_gpio_num != 0xff) {
+			Pinmux_Config(pm_pad_node_array[cur_output_pad_node->next_gpio_num].pad_num,
+				      DWGPIO);
+
 			Pad_SetControlMode(
-			pm_pad_node_array[cur_output_pad_node->next_gpio_num].pad_num,
-			PAD_PINMUX_MODE);
+				pm_pad_node_array[cur_output_pad_node->next_gpio_num].pad_num,
+				PAD_PINMUX_MODE);
 			cur_output_pad_node =
-			&(pm_pad_node_array[cur_output_pad_node->next_gpio_num]);
+				&(pm_pad_node_array[cur_output_pad_node->next_gpio_num]);
 		}
 
 		while (cur_wakeup_pad_node->next_gpio_num != 0xff) {
+			Pinmux_Config(pm_pad_node_array[cur_wakeup_pad_node->next_gpio_num].pad_num,
+				      DWGPIO);
+
 			Pad_SetControlMode(
-			pm_pad_node_array[cur_wakeup_pad_node->next_gpio_num].pad_num,
-			PAD_PINMUX_MODE);
+				pm_pad_node_array[cur_wakeup_pad_node->next_gpio_num].pad_num,
+				PAD_PINMUX_MODE);
 			System_WakeUpPinDisable(
-			pm_pad_node_array[cur_wakeup_pad_node->next_gpio_num].pad_num);
+				pm_pad_node_array[cur_wakeup_pad_node->next_gpio_num].pad_num);
 			cur_wakeup_pad_node =
-			&(pm_pad_node_array[cur_wakeup_pad_node->next_gpio_num]);
+				&(pm_pad_node_array[cur_wakeup_pad_node->next_gpio_num]);
 		}
 
 		GPIO_DLPSExit(port_base, &data->store_buf);
@@ -565,8 +566,7 @@ static int gpio_rtl87x2g_pm_action(const struct device *port,
 }
 #endif /* CONFIG_PM_DEVICE */
 
-static const struct gpio_driver_api gpio_rtl87x2g_driver_api =
-{
+static const struct gpio_driver_api gpio_rtl87x2g_driver_api = {
 	.pin_configure = gpio_rtl87x2g_pin_configure,
 	.port_get_raw = gpio_rtl87x2g_port_get_raw,
 	.port_set_masked_raw = gpio_rtl87x2g_port_set_masked_raw,
@@ -616,14 +616,12 @@ static int gpio_rtl87x2g_init(const struct device *dev)
 	const struct gpio_rtl87x2g_config *config = dev->config;
 	int ret = 0;
 
-	(void)clock_control_on(RTL87X2G_CLOCK_CONTROLLER,
-	(clock_control_subsys_t)&config->clkid);
+	(void)clock_control_on(RTL87X2G_CLOCK_CONTROLLER, (clock_control_subsys_t)&config->clkid);
 
 	for (uint8_t i = 0; i < config->irq_info->num_irq; ++i) {
 		irq_connect_dynamic(config->irq_info->gpio_irqs[i].irq,
-							config->irq_info->gpio_irqs[i].priority,
-							(const void *)gpio_rtl87x2g_isr, dev,
-							0);
+				    config->irq_info->gpio_irqs[i].priority,
+				    (const void *)gpio_rtl87x2g_isr, dev, 0);
 		irq_enable(config->irq_info->gpio_irqs[i].irq);
 	}
 
@@ -641,63 +639,49 @@ static int gpio_rtl87x2g_init(const struct device *dev)
 	return ret;
 }
 
-#define GPIO_RTL87X2G_SET_GPIO_IRQ_INFO(irq_idx, index)	\
-	{	\
-		.irq  = DT_INST_IRQ_BY_IDX(index, irq_idx, irq),	\
-		.priority = DT_INST_IRQ_BY_IDX(index, irq_idx, priority),	\
+#define GPIO_RTL87X2G_SET_GPIO_IRQ_INFO(irq_idx, index)                                            \
+	{                                                                                          \
+		.irq = DT_INST_IRQ_BY_IDX(index, irq_idx, irq),                                    \
+		.priority = DT_INST_IRQ_BY_IDX(index, irq_idx, priority),                          \
 	}
 
-#define GPIO_RTL87X2G_SET_IRQ_INFO(index)	\
-	static struct gpio_rtl87x2g_irq_info gpio_rtl87x2g_irq_info##index = {	\
-		.gpio_irqs = {	\
-					LISTIFY(DT_NUM_IRQS(DT_DRV_INST(index)),	\
-					GPIO_RTL87X2G_SET_GPIO_IRQ_INFO, (,), index)	\
-				},	\
-		.num_irq = DT_NUM_IRQS(DT_DRV_INST(index))	\
-	};	\
+#define GPIO_RTL87X2G_SET_IRQ_INFO(index)                                                          \
+	static struct gpio_rtl87x2g_irq_info gpio_rtl87x2g_irq_info##index = {                     \
+		.gpio_irqs = {LISTIFY(DT_NUM_IRQS(DT_DRV_INST(index)),                             \
+				      GPIO_RTL87X2G_SET_GPIO_IRQ_INFO, (,), index)},              \
+		.num_irq = DT_NUM_IRQS(DT_DRV_INST(index))};
 
-
-#define GPIO_RTL87X2G_GET_IRQ_INFO(index)	\
-	.irq_info = &gpio_rtl87x2g_irq_info##index,	\
+#define GPIO_RTL87X2G_GET_IRQ_INFO(index) .irq_info = &gpio_rtl87x2g_irq_info##index,
 
 #ifdef CONFIG_PM_DEVICE
-#define GPIO_RTL87X2G_ARRAY_DEFINE(index)	\
-	struct pm_pad_node pm_pad_node_array##index[32 + 1 + 1];
+#define GPIO_RTL87X2G_ARRAY_DEFINE(index) struct pm_pad_node pm_pad_node_array##index[32 + 1 + 1];
 
-#define GPIO_RTL87X2G_DATA_INIT(index)	\
-	.list.array = pm_pad_node_array##index,	\
-	.list.output_head = NULL,	\
-	.list.wakeup_head = NULL,	\
+#define GPIO_RTL87X2G_DATA_INIT(index)                                                             \
+	.list.array = pm_pad_node_array##index, .list.output_head = NULL, .list.wakeup_head = NULL,
 
 #else
 #define GPIO_RTL87X2G_ARRAY_DEFINE(index)
 #define GPIO_RTL87X2G_DATA_INIT(index)
 #endif
 
-#define GPIO_RTL87X2G_DEVICE_INIT(index)	\
-	GPIO_RTL87X2G_ARRAY_DEFINE(index)	\
-	GPIO_RTL87X2G_SET_IRQ_INFO(index)	\
-	static const struct gpio_rtl87x2g_config gpio_rtl87x2g_port##index##_cfg = {	\
-		.common = {	\
-					.port_pin_mask =	\
-					GPIO_PORT_PIN_MASK_FROM_DT_INST(index),	\
-				},	\
-		.port_num = DT_INST_PROP(index, port),	\
-		.port_base = (GPIO_TypeDef *)DT_INST_REG_ADDR(index),	\
-		.clkid = DT_INST_CLOCKS_CELL(index, id),	\
-		GPIO_RTL87X2G_GET_IRQ_INFO(index)	\
-	};	\
-	\
-	static struct gpio_rtl87x2g_data gpio_rtl87x2g_port##index##_data = {	\
-		GPIO_RTL87X2G_DATA_INIT(index)	\
-	};	\
-	 PM_DEVICE_DT_INST_DEFINE(index, gpio_rtl87x2g_pm_action);	\
-	 DEVICE_DT_INST_DEFINE(index, gpio_rtl87x2g_init,	\
-						PM_DEVICE_DT_INST_GET(index),	\
-						&gpio_rtl87x2g_port##index##_data,	\
-						&gpio_rtl87x2g_port##index##_cfg,	\
-						PRE_KERNEL_1,	\
-						CONFIG_GPIO_INIT_PRIORITY,	\
-						&gpio_rtl87x2g_driver_api);
+#define GPIO_RTL87X2G_DEVICE_INIT(index)                                                           \
+	GPIO_RTL87X2G_ARRAY_DEFINE(index)                                                          \
+	GPIO_RTL87X2G_SET_IRQ_INFO(index)                                                          \
+	static const struct gpio_rtl87x2g_config gpio_rtl87x2g_port##index##_cfg = {               \
+		.common =                                                                          \
+			{                                                                          \
+				.port_pin_mask = GPIO_PORT_PIN_MASK_FROM_DT_INST(index),           \
+			},                                                                         \
+		.port_num = DT_INST_PROP(index, port),                                             \
+		.port_base = (GPIO_TypeDef *)DT_INST_REG_ADDR(index),                              \
+		.clkid = DT_INST_CLOCKS_CELL(index, id),                                           \
+		GPIO_RTL87X2G_GET_IRQ_INFO(index)};                                                \
+                                                                                                   \
+	static struct gpio_rtl87x2g_data gpio_rtl87x2g_port##index##_data = {                      \
+		GPIO_RTL87X2G_DATA_INIT(index)};                                                   \
+	PM_DEVICE_DT_INST_DEFINE(index, gpio_rtl87x2g_pm_action);                                  \
+	DEVICE_DT_INST_DEFINE(index, gpio_rtl87x2g_init, PM_DEVICE_DT_INST_GET(index),             \
+			      &gpio_rtl87x2g_port##index##_data, &gpio_rtl87x2g_port##index##_cfg, \
+			      PRE_KERNEL_1, CONFIG_GPIO_INIT_PRIORITY, &gpio_rtl87x2g_driver_api);
 
 DT_INST_FOREACH_STATUS_OKAY(GPIO_RTL87X2G_DEVICE_INIT)

--- a/drivers/i2c/Kconfig.rtl87x2g
+++ b/drivers/i2c/Kconfig.rtl87x2g
@@ -10,3 +10,13 @@ config I2C_RTL87X2G
 	select USE_HAL_REALTEK_I2C
 	help
 	  Enable the RTL87X2G i2c driver.
+
+if I2C_RTL87X2G
+
+config I2C_RTL87X2G_INTERRUPT
+	bool
+	default n
+	help
+	  Do transfer with i2c interrupt.
+
+endif

--- a/drivers/i2c/i2c_rtl87x2g.c
+++ b/drivers/i2c/i2c_rtl87x2g.c
@@ -1,5 +1,5 @@
 /*
- * Copyright(c) 2020, Realtek Semiconductor Corporation.
+ * Copyright(c) 2024, Realtek Semiconductor Corporation.
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -27,435 +27,472 @@ LOG_MODULE_REGISTER(i2c_rtl87x2g, CONFIG_I2C_LOG_LEVEL);
 #include <rtl_i2c.h>
 #include <rtl_rcc.h>
 
-struct i2c_rtl87x2g_config
-{
-    uint32_t reg;
-    uint32_t bitrate;
-    uint16_t clkid;
-    const struct pinctrl_dev_config *pcfg;
-    void (*irq_cfg_func)(void);
+#define I2C_TIMEOUT 0xFFFFF
+
+struct i2c_rtl87x2g_config {
+	uint32_t reg;
+	uint32_t bitrate;
+	uint16_t clkid;
+	const struct pinctrl_dev_config *pcfg;
+#if defined(CONFIG_I2C_RTL87X2G_INTERRUPT)
+	void (*irq_cfg_func)(void);
+#endif
 };
 
-struct i2c_rtl87x2g_data
-{
-    struct k_sem bus_mutex;
-    struct k_sem sync_sem;
-    uint32_t dev_config;
-    uint16_t slave_address;
-    uint32_t xfer_len;
-    struct i2c_msg *current;
-    uint8_t errs;
-    bool is_restart;
+struct i2c_rtl87x2g_data {
+	struct k_sem bus_mutex;
+#if defined(CONFIG_I2C_RTL87X2G_INTERRUPT)
+	struct k_sem sync_sem;
+#endif
+	uint32_t dev_config;
+	uint16_t slave_address;
+	uint32_t xfer_len;
+	struct i2c_msg *current;
+	uint8_t errs;
+	bool is_restart;
 #ifdef CONFIG_PM_DEVICE
-    I2CStoreReg_Typedef store_buf;
+	I2CStoreReg_Typedef store_buf;
 #endif
 };
 
 static void i2c_rtl87x2g_log_err(struct i2c_rtl87x2g_data *data)
 {
-    LOG_DBG("i2c_rtl87x2g_log_err line%d\n", __LINE__);
-    if (data->errs == I2C_ABRT_7B_ADDR_NOACK)
-    {
-        LOG_ERR("7 bit address no ack error");
-    }
+	LOG_DBG("i2c_rtl87x2g_log_err line%d\n", __LINE__);
+	if (data->errs == I2C_ABRT_7B_ADDR_NOACK) {
+		LOG_ERR("7 bit address no ack error");
+	}
 
-    if (data->errs == I2C_ABRT_10ADDR1_NOACK || \
-        data->errs == I2C_ABRT_10ADDR2_NOACK)
-    {
-        LOG_ERR("10 bit address no ack error");
-    }
+	if (data->errs == I2C_ABRT_10ADDR1_NOACK || data->errs == I2C_ABRT_10ADDR2_NOACK) {
+		LOG_ERR("10 bit address no ack error");
+	}
 
-    if (data->errs == I2C_ABRT_TXDATA_NOACK)
-    {
-        LOG_ERR("data no ack error");
-    }
+	if (data->errs == I2C_ABRT_TXDATA_NOACK) {
+		LOG_ERR("data no ack error");
+	}
 
-    if (data->errs == I2C_ARB_LOST)
-    {
-        LOG_ERR("arbitration lost error");
-    }
+	if (data->errs == I2C_ARB_LOST) {
+		LOG_ERR("arbitration lost error");
+	}
+
+	if (data->errs == I2C_ERR_TIMEOUT) {
+		LOG_ERR("timeout");
+	}
 }
 
-
+#if defined(CONFIG_I2C_RTL87X2G_INTERRUPT)
 static void i2c_rtl87x2g_isr(const struct device *dev)
 {
-    LOG_DBG("i2c_rtl87x2g_isr line%d\n", __LINE__);
-    struct i2c_rtl87x2g_data *data = dev->data;
-    const struct i2c_rtl87x2g_config *cfg = dev->config;
-    I2C_TypeDef *i2c = (I2C_TypeDef *)cfg->reg;
-    if (I2C_GetINTStatus(i2c, I2C_INT_TX_ABRT))
-    {
-        data->errs = I2C_CheckAbortStatus(i2c);
-        I2C_INTConfig(i2c, I2C_INT_TX_ABRT | I2C_INT_RX_FULL | I2C_INT_TX_EMPTY, DISABLE);
-        I2C_ClearINTPendingBit(i2c, I2C_INT_TX_ABRT);
-        I2C_ClearINTPendingBit(i2c, I2C_INT_RX_FULL);
-        I2C_ClearINTPendingBit(i2c, I2C_INT_TX_EMPTY);
-        k_sem_give(&data->sync_sem);
-    }
-    else if (I2C_GetINTStatus(i2c, I2C_INT_RX_FULL))
-    {
-        I2C_INTConfig(i2c, I2C_INT_RX_FULL, DISABLE);
-        I2C_ClearINTPendingBit(i2c, I2C_INT_RX_FULL);
-        k_sem_give(&data->sync_sem);
-    }
-    else if (I2C_GetINTStatus(i2c, I2C_INT_TX_EMPTY))
-    {
-        I2C_INTConfig(i2c, I2C_INT_TX_EMPTY, DISABLE);
-        I2C_ClearINTPendingBit(i2c, I2C_INT_TX_EMPTY);
-        k_sem_give(&data->sync_sem);
-    }
-}
+	LOG_DBG("i2c_rtl87x2g_isr line%d\n", __LINE__);
+	struct i2c_rtl87x2g_data *data = dev->data;
+	const struct i2c_rtl87x2g_config *cfg = dev->config;
+	I2C_TypeDef *i2c = (I2C_TypeDef *)cfg->reg;
 
+	if (I2C_GetINTStatus(i2c, I2C_INT_TX_ABRT)) {
+		data->errs = I2C_CheckAbortStatus(i2c);
+		I2C_INTConfig(i2c, I2C_INT_TX_ABRT | I2C_INT_RX_FULL | I2C_INT_TX_EMPTY, DISABLE);
+		I2C_ClearINTPendingBit(i2c, I2C_INT_TX_ABRT);
+		I2C_ClearINTPendingBit(i2c, I2C_INT_RX_FULL);
+		I2C_ClearINTPendingBit(i2c, I2C_INT_TX_EMPTY);
+		k_sem_give(&data->sync_sem);
+	} else if (I2C_GetINTStatus(i2c, I2C_INT_RX_FULL)) {
+		I2C_INTConfig(i2c, I2C_INT_RX_FULL, DISABLE);
+		I2C_ClearINTPendingBit(i2c, I2C_INT_RX_FULL);
+		k_sem_give(&data->sync_sem);
+	} else if (I2C_GetINTStatus(i2c, I2C_INT_TX_EMPTY)) {
+		I2C_INTConfig(i2c, I2C_INT_TX_EMPTY, DISABLE);
+		I2C_ClearINTPendingBit(i2c, I2C_INT_TX_EMPTY);
+		k_sem_give(&data->sync_sem);
+	}
+}
+#endif
 
 static int i2c_rtl87x2g_msg_handler(const struct device *dev)
 {
-    struct i2c_rtl87x2g_data *data = dev->data;
-    const struct i2c_rtl87x2g_config *cfg = dev->config;
-    I2C_TypeDef *i2c = (I2C_TypeDef *)cfg->reg;
-    bool read_f = (data->current->flags & I2C_MSG_RW_MASK) == I2C_MSG_READ;
-    bool stop_f = (data->current->flags & I2C_MSG_STOP);
-    data->errs = 0;
+	struct i2c_rtl87x2g_data *data = dev->data;
+	const struct i2c_rtl87x2g_config *cfg = dev->config;
+	I2C_TypeDef *i2c = (I2C_TypeDef *)cfg->reg;
+	bool read_f = (data->current->flags & I2C_MSG_RW_MASK) == I2C_MSG_READ;
+	bool stop_f = (data->current->flags & I2C_MSG_STOP);
 
-    k_sem_reset(&data->sync_sem);
+	data->errs = 0;
 
-    if (read_f)
-    {
-        LOG_DBG("i2c_rtl87x2g_msg_handler read line%d\n", __LINE__);
-        for (uint32_t cnt = 0; cnt < data->xfer_len; ++cnt)
-        {
-            if (cnt >= data->xfer_len - 1)
-            {
-                i2c->IC_DATA_CMD = I2C_0X10_CMD | (stop_f ? I2C_0X10_STOP : 0);
-            }
-            else
-            {
-                i2c->IC_DATA_CMD = I2C_0X10_CMD;
-            }
+#if !defined(CONFIG_I2C_RTL87X2G_INTERRUPT)
+	uint32_t timeout;
+#else
+	k_sem_reset(&data->sync_sem);
+#endif
 
-            I2C_INTConfig(i2c, I2C_INT_RX_FULL | I2C_INT_TX_ABRT, ENABLE);
+	if (read_f) {
+		for (uint32_t cnt = 0; cnt < data->xfer_len; ++cnt) {
+			if (cnt >= data->xfer_len - 1) {
+				i2c->IC_DATA_CMD = I2C_0X10_CMD | (stop_f ? I2C_0X10_STOP : 0);
+			} else {
+				i2c->IC_DATA_CMD = I2C_0X10_CMD;
+			}
 
-            /* wait for interrupt */
-            k_sem_take(&data->sync_sem, K_FOREVER);
+			I2C_INTConfig(i2c, I2C_INT_RX_FULL | I2C_INT_TX_ABRT, ENABLE);
 
-            if (data->errs != I2C_Success)
-            {
-                return -EIO;
-            }
+			/* wait for interrupt */
+#if defined(CONFIG_I2C_RTL87X2G_INTERRUPT)
+			k_sem_take(&data->sync_sem, K_FOREVER);
+#else
+			timeout = I2C_TIMEOUT;
+			while (!(I2C_GetINTStatus(i2c, I2C_INT_TX_ABRT) ||
+				 I2C_GetINTStatus(i2c, I2C_INT_RX_FULL))) {
+				timeout--;
+				if (timeout == 0) {
+					return -EIO;
+				}
+			}
+			if (I2C_GetINTStatus(i2c, I2C_INT_TX_ABRT)) {
+				data->errs = I2C_CheckAbortStatus(i2c);
+				I2C_INTConfig(i2c,
+					      I2C_INT_TX_ABRT | I2C_INT_RX_FULL | I2C_INT_TX_EMPTY,
+					      DISABLE);
+				I2C_ClearINTPendingBit(i2c, I2C_INT_TX_ABRT);
+				I2C_ClearINTPendingBit(i2c, I2C_INT_RX_FULL);
+				I2C_ClearINTPendingBit(i2c, I2C_INT_TX_EMPTY);
+			} else if (I2C_GetINTStatus(i2c, I2C_INT_RX_FULL)) {
+				I2C_INTConfig(i2c, I2C_INT_RX_FULL, DISABLE);
+				I2C_ClearINTPendingBit(i2c, I2C_INT_RX_FULL);
+			}
+#endif
 
-            *data->current->buf++ = i2c->IC_DATA_CMD;
-        }
+			if (data->errs != I2C_Success) {
+				return -EIO;
+			}
 
-    }
-    else
-    {
-        LOG_DBG("i2c_rtl87x2g_msg_handler write line%d\n", __LINE__);
-        for (uint32_t cnt = 0; cnt < data->xfer_len; ++cnt)
-        {
-            if (cnt >= data->xfer_len - 1)
-            {
-                i2c->IC_DATA_CMD = *data->current->buf++ | (stop_f ? I2C_0X10_STOP : 0);
-            }
-            else
-            {
-                i2c->IC_DATA_CMD = *data->current->buf++;
-            }
+			*data->current->buf++ = i2c->IC_DATA_CMD;
+		}
 
-            data->errs = I2C_CheckAbortStatus(i2c);
-            if (data->errs != I2C_Success)
-            {
-                return -EIO;
-            }
+	} else {
+		for (uint32_t cnt = 0; cnt < data->xfer_len; ++cnt) {
+			if (cnt >= data->xfer_len - 1) {
+				i2c->IC_DATA_CMD =
+					*data->current->buf++ | (stop_f ? I2C_0X10_STOP : 0);
+			} else {
+				i2c->IC_DATA_CMD = *data->current->buf++;
+			}
 
-            if (i2c->IC_STATUS & I2C_FLAG_TFNF)
-            {
-                continue;
-            }
+			data->errs = I2C_CheckAbortStatus(i2c);
+			if (data->errs != I2C_Success) {
+				return -EIO;
+			}
 
-            I2C_INTConfig(i2c, I2C_INT_TX_EMPTY | I2C_INT_TX_ABRT, ENABLE);
-            /* wait for interrupt */
-            k_sem_take(&data->sync_sem, K_FOREVER);
+			if (i2c->IC_STATUS & I2C_FLAG_TFNF) {
+				continue;
+			}
 
-            if (data->errs != I2C_Success)
-            {
-                return -EIO;
-            }
-        }
+			I2C_INTConfig(i2c, I2C_INT_TX_EMPTY | I2C_INT_TX_ABRT, ENABLE);
 
-        I2C_INTConfig(i2c, I2C_INT_TX_EMPTY | I2C_INT_TX_ABRT, ENABLE);
-        /* wait for interrupt */
-        k_sem_take(&data->sync_sem, K_FOREVER);
-        if (data->errs != I2C_Success)
-        {
-            return -EIO;
-        }
+			/* wait for interrupt */
+#if defined(CONFIG_I2C_RTL87X2G_INTERRUPT)
+			k_sem_take(&data->sync_sem, K_FOREVER);
+#else
+			timeout = I2C_TIMEOUT;
+			while (!(I2C_GetINTStatus(i2c, I2C_INT_TX_ABRT) ||
+				 I2C_GetINTStatus(i2c, I2C_INT_TX_EMPTY))) {
+				timeout--;
+				if (timeout == 0) {
+					return -EIO;
+				}
+			}
 
-    }
+			if (I2C_GetINTStatus(i2c, I2C_INT_TX_ABRT)) {
+				data->errs = I2C_CheckAbortStatus(i2c);
+				I2C_INTConfig(i2c,
+					      I2C_INT_TX_ABRT | I2C_INT_RX_FULL | I2C_INT_TX_EMPTY,
+					      DISABLE);
+				I2C_ClearINTPendingBit(i2c, I2C_INT_TX_ABRT);
+				I2C_ClearINTPendingBit(i2c, I2C_INT_RX_FULL);
+				I2C_ClearINTPendingBit(i2c, I2C_INT_TX_EMPTY);
+			} else if (I2C_GetINTStatus(i2c, I2C_INT_TX_EMPTY)) {
+				I2C_INTConfig(i2c, I2C_INT_TX_EMPTY, DISABLE);
+				I2C_ClearINTPendingBit(i2c, I2C_INT_TX_EMPTY);
+			}
+#endif
 
-    LOG_DBG("i2c_rtl87x2g_msg_handler exit line%d\n", __LINE__);
+			if (data->errs != I2C_Success) {
+				return -EIO;
+			}
+		}
 
-    return 0;
+		I2C_INTConfig(i2c, I2C_INT_TX_EMPTY | I2C_INT_TX_ABRT, ENABLE);
+
+		/* wait for interrupt */
+#if defined(CONFIG_I2C_RTL87X2G_INTERRUPT)
+		k_sem_take(&data->sync_sem, K_FOREVER);
+#else
+		timeout = I2C_TIMEOUT;
+		while (!(I2C_GetINTStatus(i2c, I2C_INT_TX_ABRT) ||
+			 I2C_GetINTStatus(i2c, I2C_INT_TX_EMPTY))) {
+			timeout--;
+			if (timeout == 0) {
+				return -EIO;
+			}
+		}
+		if (I2C_GetINTStatus(i2c, I2C_INT_TX_ABRT)) {
+			data->errs = I2C_CheckAbortStatus(i2c);
+			I2C_INTConfig(i2c, I2C_INT_TX_ABRT | I2C_INT_RX_FULL | I2C_INT_TX_EMPTY,
+				      DISABLE);
+			I2C_ClearINTPendingBit(i2c, I2C_INT_TX_ABRT);
+			I2C_ClearINTPendingBit(i2c, I2C_INT_RX_FULL);
+			I2C_ClearINTPendingBit(i2c, I2C_INT_TX_EMPTY);
+		} else if (I2C_GetINTStatus(i2c, I2C_INT_TX_EMPTY)) {
+			I2C_INTConfig(i2c, I2C_INT_TX_EMPTY, DISABLE);
+			I2C_ClearINTPendingBit(i2c, I2C_INT_TX_EMPTY);
+		}
+#endif
+		if (data->errs != I2C_Success) {
+			return -EIO;
+		}
+	}
+
+	LOG_DBG("i2c_rtl87x2g_msg_handler exit line%d\n", __LINE__);
+
+	return 0;
 }
 
-static int i2c_rtl87x2g_transfer(const struct device *dev,
-                                 struct i2c_msg *msgs,
-                                 uint8_t num_msgs,
-                                 uint16_t addr)
+static int i2c_rtl87x2g_transfer(const struct device *dev, struct i2c_msg *msgs, uint8_t num_msgs,
+				 uint16_t addr)
 {
-    LOG_DBG("i2c_rtl87x2g_transfer, num_msgs=%d line%d\n", num_msgs, __LINE__);
-    struct i2c_rtl87x2g_data *data = dev->data;
-    const struct i2c_rtl87x2g_config *cfg = dev->config;
-    I2C_TypeDef *i2c = (I2C_TypeDef *)cfg->reg;
-    struct i2c_msg *current, *next;
-    int err = 0;
+	struct i2c_rtl87x2g_data *data = dev->data;
+	const struct i2c_rtl87x2g_config *cfg = dev->config;
+	I2C_TypeDef *i2c = (I2C_TypeDef *)cfg->reg;
+	struct i2c_msg *current, *next;
+	int err = 0;
 
-    current = msgs;
+	current = msgs;
 
-    /* First message flags implicitly contain I2C_MSG_RESTART flag. */
-    current->flags |= I2C_MSG_RESTART;
+	/* First message flags implicitly contain I2C_MSG_RESTART flag. */
+	current->flags |= I2C_MSG_RESTART;
 
-    for (uint8_t i = 1; i <= num_msgs; i++)
-    {
+	for (uint8_t i = 1; i <= num_msgs; i++) {
 
-        if (i < num_msgs)
-        {
-            next = current + 1;
+		if (i < num_msgs) {
+			next = current + 1;
 
-            /*
-            * If there have a R/W transfer state change between messages,
-            * An explicit I2C_MSG_RESTART flag is needed for the second message.
-            */
-            if ((current->flags & I2C_MSG_RW_MASK) !=
-                (next->flags & I2C_MSG_RW_MASK))
-            {
-                if ((next->flags & I2C_MSG_RESTART) == 0U)
-                {
-                    return -EINVAL;
-                }
-            }
+			/*
+			 * If there have a R/W transfer state change between messages,
+			 * An explicit I2C_MSG_RESTART flag is needed for the second message.
+			 */
+			if ((current->flags & I2C_MSG_RW_MASK) != (next->flags & I2C_MSG_RW_MASK)) {
+				if ((next->flags & I2C_MSG_RESTART) == 0U) {
+					return -EINVAL;
+				}
+			}
 
-            /* Only the last message need I2C_MSG_STOP flag to free the Bus. */
-            if (current->flags & I2C_MSG_STOP)
-            {
-                return -EINVAL;
-            }
-        }
-        else
-        {
-            /* Last message flags implicitly contain I2C_MSG_STOP flag. */
-            current->flags |= I2C_MSG_STOP;
-        }
+			/* Only the last message need I2C_MSG_STOP flag to free the Bus. */
+			if (current->flags & I2C_MSG_STOP) {
+				return -EINVAL;
+			}
+		} else {
+			/* Last message flags implicitly contain I2C_MSG_STOP flag. */
+			current->flags |= I2C_MSG_STOP;
+		}
 
-        if ((current->buf == NULL) ||
-            (current->len == 0U))
-        {
-            return -EINVAL;
-        }
+		if ((current->buf == NULL) || (current->len == 0U)) {
+			return -EINVAL;
+		}
 
-        current++;
-    }
+		current++;
+	}
 
-    k_sem_take(&data->bus_mutex, K_FOREVER);
+	k_sem_take(&data->bus_mutex, K_FOREVER);
 
-    /* Enable i2c device */
-    I2C_Cmd(i2c, ENABLE);
+	/* Enable i2c device */
+	I2C_Cmd(i2c, ENABLE);
 
-    I2C_SetSlaveAddress(i2c, addr);
-    data->slave_address = addr;
+	I2C_SetSlaveAddress(i2c, addr);
+	data->slave_address = addr;
 
-    for (uint8_t i = 0; i < num_msgs; ++i)
-    {
-        data->current = &msgs[i];
-        data->xfer_len = msgs[i].len;
+	for (uint8_t i = 0; i < num_msgs; ++i) {
+		data->current = &msgs[i];
+		data->xfer_len = msgs[i].len;
 
-        err = i2c_rtl87x2g_msg_handler(dev);
+		err = i2c_rtl87x2g_msg_handler(dev);
 
-        if (err < 0)
-        {
-            i2c_rtl87x2g_log_err(data);
-            break;
-        }
-    }
+		if (err < 0) {
+			i2c_rtl87x2g_log_err(data);
+			break;
+		}
+	}
 
-    /* Disable I2C device */
-    I2C_Cmd(i2c, DISABLE);
+	/* Disable I2C device */
+	I2C_Cmd(i2c, DISABLE);
 
-    k_sem_give(&data->bus_mutex);
-
-    return err;
+	k_sem_give(&data->bus_mutex);
+	return err;
 }
 
-static int i2c_rtl87x2g_configure(const struct device *dev,
-                                  uint32_t dev_config)
+static int i2c_rtl87x2g_configure(const struct device *dev, uint32_t dev_config)
 {
-    LOG_DBG("i2c_rtl87x2g_configure line%d\n", __LINE__);
-    struct i2c_rtl87x2g_data *data = dev->data;
-    const struct i2c_rtl87x2g_config *cfg = dev->config;
-    uint32_t pclk;
-    I2C_TypeDef *i2c = (I2C_TypeDef *)cfg->reg;
-    int err = 0;
+	struct i2c_rtl87x2g_data *data = dev->data;
+	const struct i2c_rtl87x2g_config *cfg = dev->config;
+	uint32_t pclk;
+	I2C_TypeDef *i2c = (I2C_TypeDef *)cfg->reg;
+	int err = 0;
 
-    k_sem_take(&data->bus_mutex, K_FOREVER);
+	k_sem_take(&data->bus_mutex, K_FOREVER);
 
-    /* Disable I2C device */
-    I2C_Cmd(i2c, DISABLE);
+	/* Disable I2C device */
+	I2C_Cmd(i2c, DISABLE);
 
-    pclk = 40000000;
+	pclk = 40000000;
 
-    I2C_InitTypeDef i2c_init_struct;
-    I2C_StructInit(&i2c_init_struct);
-    i2c_init_struct.I2C_Clock = pclk;
-    if (dev_config & I2C_MODE_CONTROLLER)
-    {
-        i2c_init_struct.I2C_DeviveMode = I2C_DeviveMode_Master;
-    }
-    else
-    {
-        i2c_init_struct.I2C_DeviveMode = I2C_DeviveMode_Slave;
-    }
+	I2C_InitTypeDef i2c_init_struct;
 
-    if (dev_config & I2C_ADDR_10_BITS)
-    {
-        i2c_init_struct.I2C_AddressMode = I2C_AddressMode_10BIT;
-    }
-    else
-    {
-        i2c_init_struct.I2C_AddressMode = I2C_AddressMode_7BIT;
-    }
+	I2C_StructInit(&i2c_init_struct);
+	i2c_init_struct.I2C_Clock = pclk;
+	if (dev_config & I2C_MODE_CONTROLLER) {
+		i2c_init_struct.I2C_DeviveMode = I2C_DeviveMode_Master;
+	} else {
+		i2c_init_struct.I2C_DeviveMode = I2C_DeviveMode_Slave;
+	}
 
-    switch (I2C_SPEED_GET(dev_config))
-    {
-    case I2C_SPEED_STANDARD:
-        i2c_init_struct.I2C_ClockSpeed = I2C_BITRATE_STANDARD;
-        break;
-    case I2C_SPEED_FAST:
-        i2c_init_struct.I2C_ClockSpeed = I2C_BITRATE_FAST;
-        break;
-    case I2C_SPEED_FAST_PLUS:
-        i2c_init_struct.I2C_ClockSpeed = I2C_BITRATE_FAST_PLUS;
-        break;
-    default:
-        err = -EINVAL;
-        goto error;
-    }
+	if (dev_config & I2C_ADDR_10_BITS) {
+		i2c_init_struct.I2C_AddressMode = I2C_AddressMode_10BIT;
+	} else {
+		i2c_init_struct.I2C_AddressMode = I2C_AddressMode_7BIT;
+	}
 
-    data->dev_config = dev_config;
+	switch (I2C_SPEED_GET(dev_config)) {
+	case I2C_SPEED_STANDARD:
+		i2c_init_struct.I2C_ClockSpeed = I2C_BITRATE_STANDARD;
+		break;
+	case I2C_SPEED_FAST:
+		i2c_init_struct.I2C_ClockSpeed = I2C_BITRATE_FAST;
+		break;
+	case I2C_SPEED_FAST_PLUS:
+		i2c_init_struct.I2C_ClockSpeed = I2C_BITRATE_FAST_PLUS;
+		break;
+	default:
+		err = -EINVAL;
+		goto error;
+	}
 
-    I2C_Init(i2c, &i2c_init_struct);
+	data->dev_config = dev_config;
 
-    I2C_Cmd(i2c, ENABLE);
+	I2C_Init(i2c, &i2c_init_struct);
+
+	I2C_Cmd(i2c, ENABLE);
 error:
-    k_sem_give(&data->bus_mutex);
+	k_sem_give(&data->bus_mutex);
 
-    return err;
+	return err;
 }
 
 #ifdef CONFIG_PM_DEVICE
-static int i2c_rtl87x2g_pm_action(const struct device *dev,
-                                  enum pm_device_action action)
+static int i2c_rtl87x2g_pm_action(const struct device *dev, enum pm_device_action action)
 {
-    struct i2c_rtl87x2g_data *data = dev->data;
-    const struct i2c_rtl87x2g_config *cfg = dev->config;
-    I2C_TypeDef *i2c = (I2C_TypeDef *)cfg->reg;
-    int err;
-    extern void I2C_DLPSEnter(void *PeriReg, void *StoreBuf);
-    extern void I2C_DLPSExit(void *PeriReg, void *StoreBuf);
+	struct i2c_rtl87x2g_data *data = dev->data;
+	const struct i2c_rtl87x2g_config *cfg = dev->config;
+	I2C_TypeDef *i2c = (I2C_TypeDef *)cfg->reg;
+	int err;
 
-    switch (action)
-    {
-    case PM_DEVICE_ACTION_SUSPEND:
+	extern void I2C_DLPSEnter(void *PeriReg, void *StoreBuf);
+	extern void I2C_DLPSExit(void *PeriReg, void *StoreBuf);
 
-        I2C_DLPSEnter(i2c, &data->store_buf);
+	switch (action) {
+	case PM_DEVICE_ACTION_SUSPEND:
 
-        /* Move pins to sleep state */
-        err = pinctrl_apply_state(cfg->pcfg, PINCTRL_STATE_SLEEP);
-        if ((err < 0) && (err != -ENOENT))
-        {
-            return err;
-        }
+		I2C_DLPSEnter(i2c, &data->store_buf);
 
-        break;
-    case PM_DEVICE_ACTION_RESUME:
-        /* Set pins to active state */
-        err = pinctrl_apply_state(cfg->pcfg, PINCTRL_STATE_DEFAULT);
-        if (err < 0)
-        {
-            return err;
-        }
+		/* Move pins to sleep state */
+		err = pinctrl_apply_state(cfg->pcfg, PINCTRL_STATE_SLEEP);
+		if ((err < 0) && (err != -ENOENT)) {
+			return err;
+		}
 
-        I2C_DLPSExit(i2c, &data->store_buf);
+		break;
+	case PM_DEVICE_ACTION_RESUME:
 
-        break;
-    default:
-        return -ENOTSUP;
-    }
+		(void)clock_control_on(RTL87X2G_CLOCK_CONTROLLER,
+				       (clock_control_subsys_t)&cfg->clkid);
 
-    return 0;
+		/* Set pins to active state */
+		err = pinctrl_apply_state(cfg->pcfg, PINCTRL_STATE_DEFAULT);
+		if (err < 0) {
+			return err;
+		}
+
+		I2C_DLPSExit(i2c, &data->store_buf);
+
+		break;
+	default:
+		return -ENOTSUP;
+	}
+
+	return 0;
 }
 #endif /* CONFIG_PM_DEVICE */
 
-static struct i2c_driver_api i2c_rtl87x2g_driver_api =
-{
-    .configure = i2c_rtl87x2g_configure,
-    .transfer = i2c_rtl87x2g_transfer,
+static struct i2c_driver_api i2c_rtl87x2g_driver_api = {
+	.configure = i2c_rtl87x2g_configure,
+	.transfer = i2c_rtl87x2g_transfer,
 };
 
 static int i2c_rtl87x2g_init(const struct device *dev)
 {
-    LOG_DBG("i2c_rtl87x2g_init line%d\n", __LINE__);
-    struct i2c_rtl87x2g_data *data = dev->data;
-    const struct i2c_rtl87x2g_config *cfg = dev->config;
-    uint32_t bitrate_cfg;
-    int err = 0;
+	struct i2c_rtl87x2g_data *data = dev->data;
+	const struct i2c_rtl87x2g_config *cfg = dev->config;
+	uint32_t bitrate_cfg;
+	int err = 0;
 
-    (void)clock_control_on(RTL87X2G_CLOCK_CONTROLLER,
-                           (clock_control_subsys_t)&cfg->clkid);
+	(void)clock_control_on(RTL87X2G_CLOCK_CONTROLLER, (clock_control_subsys_t)&cfg->clkid);
 
-    /* Configure pinmux  */
+	/* Configure pinmux  */
+	err = pinctrl_apply_state(cfg->pcfg, PINCTRL_STATE_DEFAULT);
+	if (err < 0) {
+		return err;
+	}
 
-    err = pinctrl_apply_state(cfg->pcfg, PINCTRL_STATE_DEFAULT);
-    if (err < 0)
-    {
-        return err;
-    }
+	/* Mutex semaphore to protect the i2c api in multi-thread env. */
+	k_sem_init(&data->bus_mutex, 1, 1);
 
-    /* Mutex semaphore to protect the i2c api in multi-thread env. */
-    k_sem_init(&data->bus_mutex, 1, 1);
+#if defined(CONFIG_I2C_RTL87X2G_INTERRUPT)
+	/* Sync semaphore to sync i2c state between isr and transfer api. */
+	k_sem_init(&data->sync_sem, 0, K_SEM_MAX_LIMIT);
+#endif
 
-    /* Sync semaphore to sync i2c state between isr and transfer api. */
-    k_sem_init(&data->sync_sem, 0, K_SEM_MAX_LIMIT);
+#if defined(CONFIG_I2C_RTL87X2G_INTERRUPT)
+	cfg->irq_cfg_func();
+#endif
 
-    cfg->irq_cfg_func();
+	bitrate_cfg = i2c_map_dt_bitrate(cfg->bitrate);
+	i2c_rtl87x2g_configure(dev, I2C_MODE_CONTROLLER | bitrate_cfg);
 
-    bitrate_cfg = i2c_map_dt_bitrate(cfg->bitrate);
-    i2c_rtl87x2g_configure(dev, I2C_MODE_CONTROLLER | bitrate_cfg);
-
-    return 0;
+	return 0;
 }
 
-#define I2C_RTL87X2G_INIT(index)                            \
-    PINCTRL_DT_INST_DEFINE(index);                      \
-    static void i2c_rtl87x2g_irq_cfg_func_##index(void)             \
-    {                                   \
-        IRQ_CONNECT(DT_INST_IRQN(index),        \
-                    DT_INST_IRQ(index, priority),       \
-                    i2c_rtl87x2g_isr,                   \
-                    DEVICE_DT_INST_GET(index),              \
-                    0);                         \
-        irq_enable(DT_INST_IRQN(index));        \
-    }                                   \
-    static struct i2c_rtl87x2g_data i2c_rtl87x2g_data_##index;          \
-    const static struct i2c_rtl87x2g_config i2c_rtl87x2g_cfg_##index = {        \
-        .reg = DT_INST_REG_ADDR(index),                 \
-               .bitrate = DT_INST_PROP(index, clock_frequency),          \
-                          .clkid = DT_INST_CLOCKS_CELL(index, id),                \
-                                   .pcfg = PINCTRL_DT_INST_DEV_CONFIG_GET(index),          \
-                                           .irq_cfg_func = i2c_rtl87x2g_irq_cfg_func_##index,          \
-    };                                  \
-     PM_DEVICE_DT_INST_DEFINE(index, i2c_rtl87x2g_pm_action);    \
-     I2C_DEVICE_DT_INST_DEFINE(index,                        \
-                              i2c_rtl87x2g_init, PM_DEVICE_DT_INST_GET(index),              \
-                              &i2c_rtl87x2g_data_##index, &i2c_rtl87x2g_cfg_##index,    \
-                              POST_KERNEL, CONFIG_I2C_INIT_PRIORITY,    \
-                              &i2c_rtl87x2g_driver_api);            \
+#if defined(CONFIG_I2C_RTL87X2G_INTERRUPT)
+#define I2C_IRQ_FUNC_DEFINE(index)                                                                 \
+	static void i2c_rtl87x2g_irq_cfg_func_##index(void)                                        \
+	{                                                                                          \
+		IRQ_CONNECT(DT_INST_IRQN(index), DT_INST_IRQ(index, priority), i2c_rtl87x2g_isr,   \
+			    DEVICE_DT_INST_GET(index), 0);                                         \
+		irq_enable(DT_INST_IRQN(index));                                                   \
+	}
+#define I2C_IRQ_CONFIG(index) .irq_cfg_func = i2c_rtl87x2g_irq_cfg_func_##index,
+#else
+#define I2C_IRQ_FUNC_DEFINE(index)
+#define I2C_IRQ_CONFIG(index)
+#endif
+
+#define I2C_RTL87X2G_INIT(index)                                                                   \
+	PINCTRL_DT_INST_DEFINE(index);                                                             \
+	I2C_IRQ_FUNC_DEFINE(index);                                                                \
+	static struct i2c_rtl87x2g_data i2c_rtl87x2g_data_##index;                                 \
+	const static struct i2c_rtl87x2g_config i2c_rtl87x2g_cfg_##index = {                       \
+		.reg = DT_INST_REG_ADDR(index),                                                    \
+		.bitrate = DT_INST_PROP(index, clock_frequency),                                   \
+		.clkid = DT_INST_CLOCKS_CELL(index, id),                                           \
+		.pcfg = PINCTRL_DT_INST_DEV_CONFIG_GET(index),                                     \
+		I2C_IRQ_CONFIG(index)};                                                            \
+	PM_DEVICE_DT_INST_DEFINE(index, i2c_rtl87x2g_pm_action);                                   \
+	I2C_DEVICE_DT_INST_DEFINE(index, i2c_rtl87x2g_init, PM_DEVICE_DT_INST_GET(index),          \
+				  &i2c_rtl87x2g_data_##index, &i2c_rtl87x2g_cfg_##index,           \
+				  POST_KERNEL, CONFIG_I2C_INIT_PRIORITY,                           \
+				  &i2c_rtl87x2g_driver_api);
 
 DT_INST_FOREACH_STATUS_OKAY(I2C_RTL87X2G_INIT)

--- a/drivers/input/input_rtl87x2g_kscan.c
+++ b/drivers/input/input_rtl87x2g_kscan.c
@@ -26,7 +26,7 @@
 #include <zephyr/pm/policy.h>
 #include <zephyr/input/input.h>
 
-#ifdef CONFIG_PM
+#ifdef CONFIG_PM_DEVICE
 #include "power_manager_unit_platform.h"
 #endif
 #include "rtl_keyscan.h"

--- a/drivers/kscan/kscan_rtl87x2g.c
+++ b/drivers/kscan/kscan_rtl87x2g.c
@@ -25,7 +25,7 @@
 #include <zephyr/pm/device.h>
 #include <zephyr/pm/policy.h>
 
-#ifdef CONFIG_PM
+#ifdef CONFIG_PM_DEVICE
 #include "power_manager_unit_platform.h"
 #endif
 #include "rtl_keyscan.h"

--- a/drivers/pinctrl/pinctrl_rtl87x2g.c
+++ b/drivers/pinctrl/pinctrl_rtl87x2g.c
@@ -45,6 +45,8 @@ static void pinctrl_configure_pin(const pinctrl_soc_pin_t *pin)
         Pinmux_Config(cfg_pin, cfg_fun);
     }
 
+	System_WakeUpPinDisable(cfg_pin);
+
     if (cfg_wakeup_high)
     {
         System_WakeUpPinEnable(cfg_pin, PAD_WAKEUP_POL_HIGH, PAD_WAKEUP_DEB_DISABLE);

--- a/drivers/rtc/rtc_rtl87x2g.c
+++ b/drivers/rtc/rtc_rtl87x2g.c
@@ -80,7 +80,7 @@ struct rtc_rtl87x2g_config {
 static const uint32_t rtc_cmp_int_table[] = {RTC_INT_COMP0, RTC_INT_COMP1, RTC_INT_COMP2,
 					     RTC_INT_COMP3};
 #ifdef CONFIG_PM_DEVICE
-static const uint32_t rtc_cmp_wk_table[] = {RTC_WK_CMP0, RTC_WK_CMP1, RTC_WK_CMP2, RTC_WK_CMP3};
+static const uint32_t rtc_cmp_wk_table[] = {RTC_WK_COMP0, RTC_WK_COMP1, RTC_WK_COMP2, RTC_WK_COMP3};
 #endif
 #endif
 
@@ -420,6 +420,8 @@ static void alarm_irq_handle(const struct device *dev, uint32_t chan)
 		rtc_rtl87x2g_alarm_set_time(dev, chan, data->alarm[chan].mask,
 					    &(data->alarm[chan].orogin_time));
 		alarm->pending = true;
+		RTC_ClearCompINT(chan);
+		RTC_INTConfig(rtc_cmp_int_table[chan], DISABLE);
 		if (cb) {
 			cb(dev, chan, alarm->user_data);
 
@@ -428,7 +430,6 @@ static void alarm_irq_handle(const struct device *dev, uint32_t chan)
 		}
 	}
 
-	RTC_ClearCompINT(chan);
 }
 #endif
 
@@ -468,6 +469,7 @@ static void rtc_irq_handler(void)
 #ifdef CONFIG_PM_DEVICE
 		if (RTC_GetWakeupStatus(rtc_cmp_wk_table[i])) {
 			RTC_ClearWakeupStatusBit(rtc_cmp_wk_table[i]);
+			RTC_WKConfig(rtc_cmp_wk_table[i], DISABLE);
 		}
 #endif
 	}

--- a/soc/realtek/bee/rtl87x2g/power.c
+++ b/soc/realtek/bee/rtl87x2g/power.c
@@ -44,11 +44,9 @@ TYPE_SECTION_START_EXTERN(const struct device *, pm_device_slots);
 /* Number of devices successfully suspended. */
 static size_t num_susp_rtk;
 
-volatile PINMUXStoreReg_Typedef Pinmux_StoreReg;
-extern void Pinmux_DLPSEnter(void *PeriReg, void *StoreBuf);
-extern void Pinmux_DLPSExit(void *PeriReg, void *StoreBuf);
 extern void NMI_Handler(void);
 extern void sys_clock_announce_process_timeout(void);
+extern void pad_short_pulse_wake_up(int Status);
 
 volatile uint32_t CPU_StoreReg[6];
 volatile uint8_t CPU_StoreReg_IPR[96];
@@ -119,9 +117,10 @@ void CPU_DLPS_Exit(void)
 
 static int pm_suspend_devices_rtk(void)
 {
+	pad_short_pulse_wake_up(1);
+	Pad_ClearAllWakeupINT();
+	System_WakeupDebounceClear(0);
 	CPU_DLPS_Enter();
-
-	Pinmux_DLPSEnter(PINMUX, (void *)&Pinmux_StoreReg);
 
 	const struct device *devs;
 	size_t devc;
@@ -159,7 +158,6 @@ static int pm_suspend_devices_rtk(void)
 
 void pm_resume_devices_rtk(void)
 {
-	Pinmux_DLPSExit(PINMUX, (void *)&Pinmux_StoreReg);
 	for (int i = (num_susp_rtk - 1); i >= 0; i--) {
 		pm_device_action_run(TYPE_SECTION_START(pm_device_slots)[i],
 				     PM_DEVICE_ACTION_RESUME);


### PR DESCRIPTION
1.use CONFIG_PM_DEVICE instead of CONFIG_PM in kscan driver;
 2.correct naming errors in rtc driver;
3.disable comp int after alarm trigger in rtc driver; 
4.config pinmux when resume in gpio driver;
5.add polling mode in i2c driver;
6.disable wakeup in pinctrl driver;
7.add pad_short_pulse_wake_up during suspend;