### PR TITLE
tests: bluetooth: tester: add rtl8762gn_evb overlay

### DIFF
--- a/tests/bluetooth/tester/boards/rtl8762gn_evb.overlay
+++ b/tests/bluetooth/tester/boards/rtl8762gn_evb.overlay
@@ -1,7 +1,25 @@
 /* SPDX-License-Identifier: Apache-2.0 */
-
 / {
 	chosen {
-		zephyr,uart-pipe = &uart2;
+		zephyr,uart-pipe = &uart3;
 	};
+};
+
+&pinctrl {
+	uart3_default: uart3_default {
+		group1 {
+			psels = <RTL87X2G_PSEL(UART3_TX, P4_0, DIR_OUT, DRV_HIGH, PULL_UP)>,
+			<RTL87X2G_PSEL(UART3_RX, P4_1, DIR_IN, DRV_HIGH, PULL_UP)>;
+		};
+	};
+};
+
+&uart3 {
+	pinctrl-0 = <&uart3_default>;
+	pinctrl-names = "default";
+	status = "okay";
+	current-speed = <115200>;
+	parity = "none";
+	stop-bits = "1";
+	data-bits = <8>;
 };


### PR DESCRIPTION
Use uart3 as uart-pipe to connect with client.