### PR TITLE
pm: rtl87x2g: restore ticks and cycles in pend stage

### DIFF
--- a/kernel/timeout.c
+++ b/kernel/timeout.c
@@ -362,12 +362,17 @@ void sys_clock_announce_only_add_ticks(int32_t ticks)
 	k_spin_unlock(&timeout_lock, key);
 }
 
+void sys_clock_restore_tick_and_cycle(void)
+{
+	/* restore cycle_count. */
+	sys_clock_only_add_cycle_count(pended_ticks);
+	/* restore cur_ticks. */
+	curr_tick += pended_ticks;
+}
 
 void sys_clock_announce_process_timeout(void)
 {
 	k_spinlock_key_t key = k_spin_lock(&timeout_lock);
-
-	sys_clock_only_add_cycle_count(pended_ticks);
 
 	struct _timeout *t;
 
@@ -376,7 +381,6 @@ void sys_clock_announce_process_timeout(void)
 	     t = first()) {
 		int dt = t->dticks;
 
-		curr_tick += dt;
 		t->dticks = 0;
 		remove_timeout(t);
 
@@ -390,7 +394,6 @@ void sys_clock_announce_process_timeout(void)
 		t->dticks -= pended_ticks;
 	}
 
-	curr_tick += pended_ticks;
 	pended_ticks = 0;
 
 	k_spin_unlock(&timeout_lock, key);

--- a/soc/realtek/bee/rtl87x2g/power.c
+++ b/soc/realtek/bee/rtl87x2g/power.c
@@ -47,6 +47,7 @@ static size_t num_susp_rtk;
 extern void NMI_Handler(void);
 extern void sys_clock_announce_process_timeout(void);
 extern void pad_short_pulse_wake_up(int Status);
+extern void sys_clock_restore_tick_and_cycle(void);
 
 volatile uint32_t CPU_StoreReg[6];
 volatile uint8_t CPU_StoreReg_IPR[96];
@@ -186,6 +187,14 @@ void device_resume_handler(struct k_work *item)
 
 void submit_items_to_rtk_pm_workq(void)
 {
+/* Restore cur_ticks and cycle_count at this point rather than waiting until
+ * work_timeout_process. This is because if you wait until work_timeout_process to
+ * restore them, there might be a situation where after restoring nvic in
+ * work_device_resume, an interrupt is triggered that enters the isr. At this point, ticks
+ * and cycle have not been restored, and if the timing API is called, it will return the
+ * values from when entering DLPS.
+ */
+	sys_clock_restore_tick_and_cycle();
 	k_work_submit_to_queue(&rtk_pm_workq, &work_device_resume);
 	k_work_submit_to_queue(&rtk_pm_workq, &work_timeout_process);
 }


### PR DESCRIPTION
Restore cur_ticks and cycle_count in pend stage rather than waiting util work_timeout_process. This is because if you wait until work_timeout_process to restore them, there might be a situation where after restoring nvic in work_device_resume, an interrupt is triggered that enters the isr. At this point, ticks and cycle have not been restored, and if the timing API is called, it will return the values from when entering DLPS.