### PR TITLE
soc: rtl87x2g: enable CONFIG_BUILTIN_STACK_GUARD

### DIFF
--- a/soc/realtek/bee/rtl87x2g/Kconfig
+++ b/soc/realtek/bee/rtl87x2g/Kconfig
@@ -14,6 +14,4 @@ config SOC_SERIES_RTL87X2G
 	select XIP
 	select HAS_PM
 	select THREAD_STACK_INFO
-
-
-
+	select BUILTIN_STACK_GUARD


### PR DESCRIPTION
Enable built-in ARM stack limit checking to realize thread stack guards.