### PR TITLE
drivers: fix issues in uart and dma driver for bee

### DIFF
--- a/drivers/dma/dma_bee.c
+++ b/drivers/dma/dma_bee.c
@@ -63,6 +63,7 @@ struct dma_bee_channel {
 	void *user_data;
 	bool busy;
 	struct dma_config cfg;
+	bool cyclic;
 	uint32_t total_size;
 	GDMA_LLIDef *p_dma_lli;
 };
@@ -340,6 +341,7 @@ static int dma_bee_configure(const struct device *dev, uint32_t channel, struct 
 			data->channels[channel].p_dma_lli[i].CTL_HIGH =
 				cur_block->block_size / dma_cfg->source_data_size;
 
+			data->channels[channel].cyclic = dma_cfg->cyclic;
 			if (dma_cfg->cyclic) {
 				data->channels[channel].total_size = cur_block->block_size;
 			} else {
@@ -704,7 +706,7 @@ static void dma_bee_isr(const struct device *dev)
 				data->channels[i].busy = false;
 			}
 
-			if (blockflag) {
+			if (blockflag && (!data->channels[i].cyclic)) {
 				data->channels[i].total_size -= GDMA_GetTransferLen(dma_channel);
 			}
 

--- a/drivers/i2s/i2s_bee.c
+++ b/drivers/i2s/i2s_bee.c
@@ -632,7 +632,7 @@ static int i2s_bee_configure(const struct device *dev, enum i2s_dir dir,
 	I2S_InitStruct.I2S_RxChSequence = I2S_RX_CH_L_R;
 	I2S_InitStruct.I2S_MCLKOutput = I2S_MCLK_128fs;
 	I2S_InitStruct.I2S_DMACmd = I2S_DMA_ENABLE;
-#if defined(CONFIG_I2S_BEE_RX)
+#if defined(CONFIG_I2S_BEE_TX)
 	I2S_InitStruct.I2S_TxWaterlevel = 64 - dev_data->dma_tx.dma_cfg.dest_burst_length;
 #endif
 #if defined(CONFIG_I2S_BEE_RX)

--- a/drivers/input/input_bee_kscan.c
+++ b/drivers/input/input_bee_kscan.c
@@ -27,7 +27,11 @@
 #include <zephyr/input/input.h>
 
 #ifdef CONFIG_PM_DEVICE
+#if defined(CONFIG_SOC_SERIES_RTL87X2G)
 #include "power_manager_unit_platform.h"
+#elif defined(CONFIG_SOC_SERIES_RTL8752H)
+#include "dlps.h"
+#endif
 #endif
 
 #if defined(CONFIG_SOC_SERIES_RTL87X2G)

--- a/drivers/ir/ir_bee.c
+++ b/drivers/ir/ir_bee.c
@@ -73,6 +73,9 @@ struct ir_bee_data {
 	uint32_t *rx_buf[2];
 	uint8_t rx_buf_index;
 	uint32_t rx_len;
+#if !(IR_HAS_RX_DMA)
+	uint32_t cur_rx_len;
+#endif
 	uint32_t rx_idle_cnt;
 	ir_callback_t cb;
 	void *cb_usr_data;
@@ -312,7 +315,11 @@ static int ir_bee_rx_init(const struct device *dev)
 	IR_InitStruct.IR_Mode = IR_MODE_RX;
 	IR_InitStruct.IR_RxStartMode = IR_RX_AUTO_MODE;
 #if !IR_HAS_RX_DMA
-	IR_InitStruct.IR_RxFIFOThrLevel = data->rx_len;
+	if (data->rx_len <= IR_RX_FIFO_SIZE) {
+		IR_InitStruct.IR_RxFIFOThrLevel = data->rx_len - 1;
+	} else {
+		IR_InitStruct.IR_RxFIFOThrLevel = 15;
+	}
 #else
 	IR_InitStruct.IR_RxFIFOThrLevel = 20;
 #endif
@@ -374,6 +381,7 @@ static int ir_bee_rx_enable(const struct device *dev, ir_callback_t callback, vo
 	data->cb = callback;
 	data->cb_usr_data = user_data;
 	data->rx_len = rx_len;
+	data->cur_rx_len = 0;
 	data->rx_idle_cnt = idle_cnt;
 	data->is_tx_mode = false;
 
@@ -467,6 +475,7 @@ static void ir_bee_isr(const struct device *dev)
 	struct ir_bee_data *data = dev->data;
 	uint8_t tx_len = data->tx_len;
 	struct ir_event evt;
+	uint8_t rx_len;
 
 	memset(&evt, 0, sizeof(evt));
 
@@ -497,20 +506,32 @@ static void ir_bee_isr(const struct device *dev)
 #if !IR_HAS_RX_DMA
 	if (IR_GetINTStatus(IR_INT_RF_LEVEL)) {
 		IR_ClearINTPendingBit(IR_INT_RF_LEVEL_CLR);
-		evt.type = IR_RX_RECEIVED;
-		evt.data.rx.len = IR_GetRxDataLen();
-		evt.data.rx.buf = data->rx_buf[0];
-		IR_ReceiveBuf(evt.data.rx.buf, evt.data.rx.len);
-		if (data->cb) {
-			data->cb(dev, &evt, data->cb_usr_data);
+
+		rx_len = IR_GetRxDataLen();
+
+		if (data->cur_rx_len <= data->rx_len - rx_len) {
+			IR_ReceiveBuf(&data->rx_buf[0][data->cur_rx_len], rx_len);
+			data->cur_rx_len += rx_len;
+		} else {
+			IR_ReceiveBuf(&data->rx_buf[0][data->cur_rx_len],
+				      data->rx_len - data->cur_rx_len);
+			data->cur_rx_len = data->rx_len;
+		}
+
+		if (data->cur_rx_len == data->rx_len) {
+			evt.type = IR_RX_RECEIVED;
+			evt.data.rx.len = data->rx_len;
+			evt.data.rx.buf = data->rx_buf[0];
+			if (data->cb) {
+				data->cb(dev, &evt, data->cb_usr_data);
+			}
+			data->cur_rx_len = 0;
 		}
 	}
 #endif
 
 	if (IR_GetINTStatus(IR_INT_RX_CNT_THR)) {
 		IR_ClearINTPendingBit(IR_INT_RX_CNT_THR_CLR);
-		evt.type = IR_RX_STOPPED;
-
 #if IR_HAS_RX_DMA
 		struct dma_status stat;
 		uint8_t remain_rx_len;
@@ -523,19 +544,55 @@ static void ir_bee_isr(const struct device *dev)
 			evt.data.rx.buf = data->rx_buf[1];
 		}
 
+		evt.type = IR_RX_STOPPED;
 		evt.data.rx.len = data->rx_len - stat.pending_length / 4;
 		remain_rx_len = IR_GetRxDataLen();
 		IR_ReceiveBuf(&evt.data.rx.buf[evt.data.rx.len], remain_rx_len);
 		evt.data.rx.len += remain_rx_len;
-#else
-		evt.data.rx.len = IR_GetRxDataLen();
-		evt.data.rx.buf = data->rx_buf[0];
-		IR_ReceiveBuf(evt.data.rx.buf, evt.data.rx.len);
-#endif
 
 		if (data->cb) {
 			data->cb(dev, &evt, data->cb_usr_data);
 		}
+
+#else
+
+		rx_len = IR_GetRxDataLen();
+
+		/* set rx 256 bytes, actual rx 257 bytes, rcv_evt 256bytes + stop_evt 1 bytes;
+		 * set rx 256 bytes, actual rx 256 bytes, stop_evt 256 bytes;
+		 * set rx 256 bytes, actual rx 255 bytes, stop_evt 255 bytes
+		 */
+		if (data->cur_rx_len <= data->rx_len - rx_len) {
+			IR_ReceiveBuf(&data->rx_buf[0][data->cur_rx_len], rx_len);
+			data->cur_rx_len += rx_len;
+		} else {
+			IR_ReceiveBuf(&data->rx_buf[0][data->cur_rx_len],
+				      data->rx_len - data->cur_rx_len);
+			data->cur_rx_len = data->rx_len;
+			evt.type = IR_RX_RECEIVED;
+			evt.data.rx.len = data->cur_rx_len;
+			evt.data.rx.buf = data->rx_buf[0];
+			if (data->cb) {
+				data->cb(dev, &evt, data->cb_usr_data);
+			}
+			data->cur_rx_len = 0;
+
+			rx_len = IR_GetRxDataLen();
+			IR_ReceiveBuf(&data->rx_buf[0][data->cur_rx_len], rx_len);
+			data->cur_rx_len += rx_len;
+		}
+
+		evt.type = IR_RX_STOPPED;
+		evt.data.rx.len = data->cur_rx_len;
+		evt.data.rx.buf = data->rx_buf[0];
+
+		if (data->cb) {
+			data->cb(dev, &evt, data->cb_usr_data);
+		}
+
+		data->cur_rx_len = 0;
+
+#endif
 	}
 }
 

--- a/drivers/kscan/kscan_bee.c
+++ b/drivers/kscan/kscan_bee.c
@@ -26,8 +26,9 @@
 #include <zephyr/pm/policy.h>
 
 #ifdef CONFIG_PM_DEVICE
+#if defined(CONFIG_SOC_SERIES_RTL87X2G)
 #include "power_manager_unit_platform.h"
-#if defined(CONFIG_SOC_SERIES_RTL8752H)
+#elif defined(CONFIG_SOC_SERIES_RTL8752H)
 #include "dlps.h"
 #endif
 #endif

--- a/drivers/serial/uart_bee.c
+++ b/drivers/serial/uart_bee.c
@@ -277,7 +277,7 @@ static int uart_bee_fifo_fill(const struct device *dev, const uint8_t *tx_data, 
 	uint8_t num_tx = 0U;
 	unsigned int key;
 
-	if (!UART_GetFlagStatus(uart, UART_FLAG_TX_EMPTY)) {
+	if (!(UART_GetTxFIFODataLen(uart) < UART_TX_FIFO_SIZE)) {
 		return num_tx;
 	}
 
@@ -285,7 +285,7 @@ static int uart_bee_fifo_fill(const struct device *dev, const uint8_t *tx_data, 
 
 	key = irq_lock();
 
-	while ((size - num_tx > 0) && UART_GetFlagStatus(uart, UART_FLAG_TX_EMPTY)) {
+	while ((size - num_tx > 0) && (UART_GetTxFIFODataLen(uart) < UART_TX_FIFO_SIZE)) {
 		UART_SendByte(uart, (uint8_t)tx_data[num_tx++]);
 	}
 

--- a/dts/bindings/ir/realtek,bee-ir.yaml
+++ b/dts/bindings/ir/realtek,bee-ir.yaml
@@ -30,6 +30,3 @@ properties:
     type: boolean
     description: Specify trigger mode in IR RX mode.
       RX will be triggered by rising edge by default.
-
-  dma-names:
-    required: true


### PR DESCRIPTION
1.Fill uart tx fifo until tx fifo len < tx fifo size to increase tx efficiency;
2.Do not decrease total size in dma block interrupt during cyclic transfer to avoid incorrect pendind size.