### PR TITLE
soc: bee: increase rtk-pm-workq-thread stack size

### DIFF
--- a/soc/realtek/bee/rtl8752h/power.c
+++ b/soc/realtek/bee/rtl8752h/power.c
@@ -213,7 +213,7 @@ void pm_resume_devices_rtk(void)
 	CPU_DLPS_Exit();
 }
 
-#define RTK_PM_WORKQ_STACK_SIZE 512
+#define RTK_PM_WORKQ_STACK_SIZE 768
 #define RTK_PM_WORKQ_PRIORITY   K_HIGHEST_THREAD_PRIO
 
 K_THREAD_STACK_DEFINE(rtk_pm_workq_stack_area, RTK_PM_WORKQ_STACK_SIZE);

--- a/soc/realtek/bee/rtl87x2g/power.c
+++ b/soc/realtek/bee/rtl87x2g/power.c
@@ -30,7 +30,7 @@
 #include <zephyr/logging/log.h>
 LOG_MODULE_REGISTER(rtl87x2g_pm, LOG_LEVEL_INF);
 
-#define RTK_PM_WORKQ_STACK_SIZE 512
+#define RTK_PM_WORKQ_STACK_SIZE 768
 #define RTK_PM_WORKQ_PRIORITY   K_HIGHEST_THREAD_PRIO
 
 K_THREAD_STACK_DEFINE(rtk_pm_workq_stack_area, RTK_PM_WORKQ_STACK_SIZE);


### PR DESCRIPTION
512 bytes is not enough for rtl8752h, increase it to 768 bytes.