### PR TITLE
drivers: uart: keep active after rx wakeup for rtl87x2g

### DIFF
--- a/drivers/dma/dma_rtl87x2g.c
+++ b/drivers/dma/dma_rtl87x2g.c
@@ -85,6 +85,10 @@ static int dma_rtl87x2g_configure(const struct device *dev, uint32_t channel,
 #endif
 
 	dma_channel_num = dma_rtl87x2g_ch2num(cfg->reg, channel);
+	if (dma_channel_num < 0) {
+		return -EINVAL;
+	}
+
 	dma_channel = (GDMA_ChannelTypeDef *)cfg->channel_base_table[dma_channel_num];
 
 	GDMA_InitTypeDef dma_init_struct;
@@ -342,6 +346,10 @@ static int dma_rtl87x2g_reload(const struct device *dev, uint32_t channel, uint3
 	GDMA_ChannelTypeDef *dma_channel;
 
 	dma_channel_num = dma_rtl87x2g_ch2num(cfg->reg, channel);
+	if (dma_channel_num < 0) {
+		return -EINVAL;
+	}
+
 	dma_channel = (GDMA_ChannelTypeDef *)cfg->channel_base_table[dma_channel_num];
 
 	if (channel >= cfg->channels) {
@@ -388,6 +396,10 @@ static int dma_rtl87x2g_start(const struct device *dev, uint32_t channel)
 	GDMA_ChannelTypeDef *dma_channel;
 
 	dma_channel_num = dma_rtl87x2g_ch2num(cfg->reg, channel);
+	if (dma_channel_num < 0) {
+		return -EINVAL;
+	}
+
 	dma_channel = (GDMA_ChannelTypeDef *)cfg->channel_base_table[dma_channel_num];
 
 	if (channel >= cfg->channels) {
@@ -436,6 +448,10 @@ static int dma_rtl87x2g_stop(const struct device *dev, uint32_t channel)
 	GDMA_ChannelTypeDef *dma_channel;
 
 	dma_channel_num = dma_rtl87x2g_ch2num(cfg->reg, channel);
+	if (dma_channel_num < 0) {
+		return -EINVAL;
+	}
+
 	dma_channel = (GDMA_ChannelTypeDef *)cfg->channel_base_table[dma_channel_num];
 
 	if (channel >= cfg->channels) {
@@ -460,6 +476,10 @@ static int dma_rtl87x2g_suspend(const struct device *dev, uint32_t channel)
 	GDMA_ChannelTypeDef *dma_channel;
 
 	dma_channel_num = dma_rtl87x2g_ch2num(cfg->reg, channel);
+	if (dma_channel_num < 0) {
+		return -EINVAL;
+	}
+
 	dma_channel = (GDMA_ChannelTypeDef *)cfg->channel_base_table[dma_channel_num];
 
 	if (channel >= cfg->channels) {
@@ -486,6 +506,10 @@ static int dma_rtl87x2g_resume(const struct device *dev, uint32_t channel)
 	GDMA_ChannelTypeDef *dma_channel;
 
 	dma_channel_num = dma_rtl87x2g_ch2num(cfg->reg, channel);
+	if (dma_channel_num < 0) {
+		return -EINVAL;
+	}
+
 	dma_channel = (GDMA_ChannelTypeDef *)cfg->channel_base_table[dma_channel_num];
 
 	if (channel >= cfg->channels) {
@@ -513,10 +537,17 @@ static int dma_rtl87x2g_get_status(const struct device *dev, uint32_t ch, struct
 {
 	const struct dma_rtl87x2g_config *cfg = dev->config;
 	struct dma_rtl87x2g_data *data = dev->data;
-	int dma_channel_num = dma_rtl87x2g_ch2num(cfg->reg, ch);
-	GDMA_ChannelTypeDef *dma_channel =
-		(GDMA_ChannelTypeDef *)cfg->channel_base_table[dma_channel_num];
-	bool suspending = GDMA_GetSuspendChannelStatus(dma_channel);
+	int dma_channel_num;
+	GDMA_ChannelTypeDef *dma_channel;
+	bool suspending;
+
+	dma_channel_num = dma_rtl87x2g_ch2num(cfg->reg, ch);
+	if (dma_channel_num < 0) {
+		return -EINVAL;
+	}
+
+	dma_channel = (GDMA_ChannelTypeDef *)cfg->channel_base_table[dma_channel_num];
+	suspending = GDMA_GetSuspendChannelStatus(dma_channel);
 
 	if (ch >= cfg->channels) {
 		LOG_ERR("channel must be < %" PRIu32 " (%" PRIu32 ")", cfg->channels, ch);
@@ -565,6 +596,10 @@ static int dma_rtl87x2g_init(const struct device *dev)
 
 	for (uint32_t i = 0; i < cfg->channels; i++) {
 		dma_channel_num = dma_rtl87x2g_ch2num(cfg->reg, i);
+		if (dma_channel_num < 0) {
+			return -EINVAL;
+		}
+
 		if (dma_channel_num >= 0) {
 			GDMA_INTConfig(dma_channel_num,
 				       GDMA_INT_Transfer | GDMA_INT_Error | GDMA_INT_Block,
@@ -589,6 +624,10 @@ static void dma_rtl87x2g_isr(const struct device *dev)
 
 	for (uint32_t i = 0; i < cfg->channels; i++) {
 		dma_channel_num = dma_rtl87x2g_ch2num(cfg->reg, i);
+		if (dma_channel_num < 0) {
+			return -EINVAL;
+		}
+
 		dma_channel = (GDMA_ChannelTypeDef *)cfg->channel_base_table[dma_channel_num];
 		errflag = ((GDMA_TypeDef *)cfg->reg)->GDMA_STATUSERR_L & BIT(dma_channel_num);
 		ftfflag = ((GDMA_TypeDef *)cfg->reg)->GDMA_STATUSTFR_L & BIT(dma_channel_num);

--- a/drivers/serial/Kconfig.rtl87x2g
+++ b/drivers/serial/Kconfig.rtl87x2g
@@ -1,6 +1,6 @@
 # RTL87X2G uart configuration
 
-# Copyright(c) 2020, Realtek Semiconductor Corporation.
+# Copyright(c) 2025, Realtek Semiconductor Corporation.
 # SPDX-License-Identifier: Apache-2.0
 
 config UART_RTL87X2G
@@ -16,4 +16,31 @@ config UART_RTL87X2G
 	select DMA if UART_ASYNC_API
 
 	help
-	  Enable the RTL87X2G uart driver.
+	  Enable the rtl87x2g uart driver.
+
+if UART_RTL87X2G
+config UART_RTL87X2G_KEEP_ACTIVE_AFTER_RX_WAKEUP
+	bool "Keep active after rx wakeup"
+	default y
+	depends on PM_DEVICE
+	help
+	  Keep active and do not allow the system to suspend after rx wakeup.
+
+if UART_RTL87X2G_KEEP_ACTIVE_AFTER_RX_WAKEUP
+config UART_RTL87X2G_KEEP_ACTIVE_MSEC
+	int "Milliseconds to keep active"
+	default 10000
+	help
+	  Time to keep active after rx wakeup in milliseconds.
+	  Note: This does not mean that the system will sleep immediately
+	  after timeout, it depends on other check status.
+
+endif # UART_RTL87X2G_KEEP_ACTIVE_AFTER_RX_WAKEUP
+
+config UART_RTL87X2G_RX_THRESHOLD
+	int "Rx threshold level to trigger interrupt"
+	default 10
+	help
+	  The Rx threshold level to trigger rx interrupt, range from 1 to 29.
+
+endif # UART_RTL87X2G

--- a/drivers/serial/uart_rtl87x2g.c
+++ b/drivers/serial/uart_rtl87x2g.c
@@ -1,5 +1,5 @@
 /*
- * Copyright(c) 2020, Realtek Semiconductor Corporation.
+ * Copyright(c) 2025, Realtek Semiconductor Corporation.
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -24,20 +24,35 @@
 #include <zephyr/pm/device.h>
 #include <zephyr/pm/policy.h>
 
+#include "uart_rtl87x2g.h"
+
 #ifdef CONFIG_UART_ASYNC_API
 #include <zephyr/drivers/dma/dma_rtl87x2g.h>
 #include <zephyr/drivers/dma.h>
 #include <rtl_gdma.h>
 #endif
 
-#include "uart_rtl87x2g.h"
 #include <rtl_uart.h>
+
+#define RTL87X2G_UART_REG_RB_THR UART_RBR_THR
+#define RTL87X2G_UART_REG_MISCR  UART_MISCR
 
 #include <zephyr/logging/log.h>
 
 #include <trace.h>
 #define DBG_DIRECT_SHOW 0
 LOG_MODULE_REGISTER(uart_rtl87x2g, CONFIG_UART_LOG_LEVEL);
+
+#ifdef CONFIG_UART_RTL87X2G_KEEP_ACTIVE_AFTER_RX_WAKEUP
+static RTL87X2G_PM_CHECK_RET uart_pm_check_state_timeout = RTL87X2G_PM_CHECK_PASS;
+
+static void uart_rx_wakeup_timer_cb(struct k_timer *timer);
+static K_TIMER_DEFINE(uart_rx_wakeup_timer, uart_rx_wakeup_timer_cb, NULL);
+
+#define DEVICE_DT_GET_AND_COMMA(node_id) DEVICE_DT_GET(node_id),
+static const struct device *const devices[] = {
+	DT_FOREACH_STATUS_OKAY(DT_DRV_COMPAT, DEVICE_DT_GET_AND_COMMA)};
+#endif
 
 static const uint32_t RTL_UART_BAUDRATE_TABLE[][3] = {
 	{271, 10, 0x24A}, /* 9600    */
@@ -84,7 +99,7 @@ static uint32_t rtl_cfg2idx_baudrate(uint32_t baudrate)
 	}
 }
 
-static UARTWordLen_TypeDef rtl_cfg2mac_data_bits(uint32_t data_bits)
+static uint16_t rtl_cfg2mac_data_bits(uint32_t data_bits)
 {
 	switch (data_bits) {
 	case UART_CFG_DATA_BITS_7:
@@ -108,7 +123,7 @@ static int rtl_cfg2mac_stopbits(uint32_t stop_bits)
 	}
 }
 
-static UARTParity_TypeDef rtl_cfg2mac_parity(uint32_t parity)
+static uint16_t rtl_cfg2mac_parity(uint32_t parity)
 {
 	switch (parity) {
 	case UART_CFG_PARITY_NONE:
@@ -173,11 +188,11 @@ static int uart_rtl87x2g_configure(const struct device *dev, const struct uart_c
 	uart_init_struct.UART_StopBits = stopbits;
 	uart_init_struct.UART_Parity = parity;
 	uart_init_struct.UART_HardwareFlowControl = cfg->flow_ctrl;
-	uart_init_struct.UART_RxThdLevel = 10;
+	uart_init_struct.UART_RxThdLevel = CONFIG_UART_RTL87X2G_RX_THRESHOLD;
 	uart_init_struct.UART_TxThdLevel = UART_TX_FIFO_SIZE / 2;
 
 #ifdef CONFIG_UART_ASYNC_API
-	uart_init_struct.UART_DmaEn = ENABLE;
+	uart_init_struct.UART_DmaEn = UART_DMA_ENABLE;
 #endif
 
 	UART_Init(uart, &uart_init_struct);
@@ -260,7 +275,7 @@ static int uart_rtl87x2g_fifo_fill(const struct device *dev, const uint8_t *tx_d
 	uint8_t num_tx = 0U;
 	unsigned int key;
 
-	if (!UART_GetFlagStatus(uart, UART_FLAG_TX_EMPTY)) {
+	if (!(UART_GetTxFIFODataLen(uart) < UART_TX_FIFO_SIZE)) {
 		return num_tx;
 	}
 
@@ -268,7 +283,7 @@ static int uart_rtl87x2g_fifo_fill(const struct device *dev, const uint8_t *tx_d
 
 	key = irq_lock();
 
-	while ((size - num_tx > 0) && UART_GetFlagStatus(uart, UART_FLAG_TX_EMPTY)) {
+	while ((size - num_tx > 0) && (UART_GetTxFIFODataLen(uart) < UART_TX_FIFO_SIZE)) {
 		UART_SendByte(uart, (uint8_t)tx_data[num_tx++]);
 	}
 
@@ -353,6 +368,7 @@ static void uart_rtl87x2g_irq_rx_enable(const struct device *dev)
 
 	data->rx_int_en = true;
 	UART_INTConfig(uart, UART_INT_RD_AVA, ENABLE);
+	UART_INTConfig(uart, UART_INT_RX_IDLE, ENABLE);
 }
 
 static void uart_rtl87x2g_irq_rx_disable(const struct device *dev)
@@ -367,18 +383,30 @@ static void uart_rtl87x2g_irq_rx_disable(const struct device *dev)
 
 	data->rx_int_en = false;
 	UART_INTConfig(uart, UART_INT_RD_AVA, DISABLE);
+	UART_INTConfig(uart, UART_INT_RX_IDLE, DISABLE);
 }
 
 static int uart_rtl87x2g_irq_rx_ready(const struct device *dev)
 {
 	const struct uart_rtl87x2g_config *config = dev->config;
 	UART_TypeDef *uart = config->uart;
+	struct uart_rtl87x2g_data *data;
+	int status;
 
 #if DBG_DIRECT_SHOW
 	DBG_DIRECT("[%s]", __func__);
 #endif
 
-	return UART_GetFlagStatus(uart, UART_FLAG_RX_DATA_AVA);
+	status = UART_GetFlagStatus(uart, UART_FLAG_RX_DATA_AVA);
+
+	data = dev->data;
+
+#ifdef CONFIG_UART_RTL87X2G_KEEP_ACTIVE_AFTER_RX_WAKEUP
+	if (status) {
+		data->uart_pm_check_state_idle = RTL87X2G_PM_CHECK_FAIL;
+	}
+#endif
+	return status;
 }
 
 static void uart_rtl87x2g_irq_err_enable(const struct device *dev)
@@ -595,11 +623,10 @@ static inline void uart_rtl87x2g_dma_tx_enable(const struct device *dev)
 	const struct uart_rtl87x2g_config *config = dev->config;
 	struct uart_rtl87x2g_data *data = dev->data;
 	UART_TypeDef *uart = config->uart;
-	UART_MISCR_TypeDef uart_0x28 = {.d32 = uart->UART_MISCR};
 
-	uart_0x28.b.txdma_en = ENABLE;
-	uart_0x28.b.txdma_burstsize = 16 - data->dma_tx.dma_cfg.dest_burst_length;
-	uart->UART_MISCR = uart_0x28.d32;
+	uart->RTL87X2G_UART_REG_MISCR &= ~(0x1f << 3);
+	uart->RTL87X2G_UART_REG_MISCR |=
+		((16 - data->dma_tx.dma_cfg.dest_burst_length) << 3) | BIT(1);
 }
 
 static inline void uart_rtl87x2g_dma_tx_disable(const struct device *dev)
@@ -608,13 +635,9 @@ static inline void uart_rtl87x2g_dma_tx_disable(const struct device *dev)
 	DBG_DIRECT("[%s]", __func__);
 #endif
 	const struct uart_rtl87x2g_config *config = dev->config;
-	struct uart_rtl87x2g_data *data = dev->data;
 	UART_TypeDef *uart = config->uart;
-	UART_MISCR_TypeDef uart_0x28 = {.d32 = uart->UART_MISCR};
 
-	uart_0x28.b.txdma_en = DISABLE;
-	uart_0x28.b.txdma_burstsize = 16 - data->dma_tx.dma_cfg.dest_burst_length;
-	uart->UART_MISCR = uart_0x28.d32;
+	uart->RTL87X2G_UART_REG_MISCR &= ~BIT(1);
 }
 
 static inline void uart_rtl87x2g_dma_rx_enable(const struct device *dev)
@@ -625,11 +648,9 @@ static inline void uart_rtl87x2g_dma_rx_enable(const struct device *dev)
 	const struct uart_rtl87x2g_config *config = dev->config;
 	struct uart_rtl87x2g_data *data = dev->data;
 	UART_TypeDef *uart = config->uart;
-	UART_MISCR_TypeDef uart_0x28 = {.d32 = uart->UART_MISCR};
 
-	uart_0x28.b.rxdma_en = ENABLE;
-	uart_0x28.b.rxdma_burstsize = data->dma_rx.dma_cfg.source_burst_length;
-	uart->UART_MISCR = uart_0x28.d32;
+	uart->RTL87X2G_UART_REG_MISCR &= ~(0x3f << 8);
+	uart->RTL87X2G_UART_REG_MISCR |= ((data->dma_rx.dma_cfg.source_burst_length) << 8) | BIT(2);
 
 	data->dma_rx.enabled = true;
 }
@@ -642,11 +663,8 @@ static inline void uart_rtl87x2g_dma_rx_disable(const struct device *dev)
 	const struct uart_rtl87x2g_config *config = dev->config;
 	struct uart_rtl87x2g_data *data = dev->data;
 	UART_TypeDef *uart = config->uart;
-	UART_MISCR_TypeDef uart_0x28 = {.d32 = uart->UART_MISCR};
 
-	uart_0x28.b.rxdma_en = DISABLE;
-	uart_0x28.b.rxdma_burstsize = data->dma_rx.dma_cfg.source_burst_length;
-	uart->UART_MISCR = uart_0x28.d32;
+	uart->RTL87X2G_UART_REG_MISCR &= ~BIT(2);
 
 	data->dma_rx.enabled = false;
 }
@@ -1017,6 +1035,9 @@ static void uart_rtl87x2g_async_rx_timeout(struct k_work *work)
 	} else {
 		uart_rtl87x2g_dma_rx_flush(dev);
 	}
+#ifdef CONFIG_UART_RTL87X2G_KEEP_ACTIVE_AFTER_RX_WAKEUP
+	data->uart_pm_check_state_idle = RTL87X2G_PM_CHECK_PASS;
+#endif
 }
 
 static int uart_rtl87x2g_async_init(const struct device *dev)
@@ -1042,6 +1063,15 @@ static int uart_rtl87x2g_async_init(const struct device *dev)
 		}
 	}
 
+	if (data->dma_tx.dma_dev == NULL && data->dma_rx.dma_dev == NULL) {
+		return 0;
+	}
+
+	atomic_set_bit(((struct dma_context *)data->dma_rx.dma_dev->data)->atomic,
+		       data->dma_rx.dma_channel);
+	atomic_set_bit(((struct dma_context *)data->dma_tx.dma_dev->data)->atomic,
+		       data->dma_tx.dma_channel);
+
 	/* Disable both TX and RX DMA requests */
 	uart_rtl87x2g_dma_rx_disable(dev);
 	uart_rtl87x2g_dma_tx_disable(dev);
@@ -1052,7 +1082,7 @@ static int uart_rtl87x2g_async_init(const struct device *dev)
 	/* Configure dma rx config */
 	memset(&data->dma_rx.blk_cfg, 0, sizeof(data->dma_rx.blk_cfg));
 
-	data->dma_rx.blk_cfg.source_address = (uint32_t)(&(uart->UART_RBR_THR));
+	data->dma_rx.blk_cfg.source_address = (uint32_t)(&(uart->RTL87X2G_UART_REG_RB_THR));
 
 	data->dma_rx.blk_cfg.dest_address = 0; /* dest not ready */
 	data->dma_rx.blk_cfg.source_addr_adj = data->dma_rx.src_addr_increment;
@@ -1070,7 +1100,7 @@ static int uart_rtl87x2g_async_init(const struct device *dev)
 	/* Configure dma tx config */
 	memset(&data->dma_tx.blk_cfg, 0, sizeof(data->dma_tx.blk_cfg));
 
-	data->dma_tx.blk_cfg.dest_address = (uint32_t)(&(uart->UART_RBR_THR));
+	data->dma_tx.blk_cfg.dest_address = (uint32_t)(&(uart->RTL87X2G_UART_REG_RB_THR));
 
 	data->dma_tx.blk_cfg.source_address = 0; /* not ready */
 
@@ -1099,34 +1129,47 @@ static void uart_rtl87x2g_isr(const struct device *dev)
 		data->user_cb(dev, data->user_data);
 	}
 
-#ifdef CONFIG_UART_ASYNC_API
 	if (UART_GetFlagStatus(uart, UART_FLAG_RX_IDLE)) {
-		if (data->dma_rx.timeout == 0) {
+#ifdef CONFIG_UART_ASYNC_API
+		if (data->dma_rx.dma_dev) {
+			if (data->dma_rx.timeout == 0) {
 #if DBG_DIRECT_SHOW
-			DBG_DIRECT("[%s] UART_FLAG_RX_IDLE timeout == 0", __func__);
+				DBG_DIRECT("[%s] UART_FLAG_RX_IDLE timeout == 0", __func__);
 #endif
-			uart_rtl87x2g_dma_rx_flush(dev);
-		} else {
+				uart_rtl87x2g_dma_rx_flush(dev);
+			} else {
 #if DBG_DIRECT_SHOW
-			extern GDMA_ChannelTypeDef *GDMA_GetGDMAChannelx(uint8_t GDMA_ChannelNum);
+				extern GDMA_ChannelTypeDef *GDMA_GetGDMAChannelx(
+					uint8_t GDMA_ChannelNum);
 
-			dma_suspend(data->dma_rx.dma_dev, data->dma_rx.dma_channel);
-			DBG_DIRECT("[%s] dma len=%d", __func__,
-				   GDMA_GetTransferLen(
-					   GDMA_GetGDMAChannelx(data->dma_rx.dma_channel)));
-			dma_resume(data->dma_rx.dma_dev, data->dma_rx.dma_channel);
+				dma_suspend(data->dma_rx.dma_dev, data->dma_rx.dma_channel);
+				DBG_DIRECT("[%s] dma len=%d", __func__,
+					   GDMA_GetTransferLen(
+						   GDMA_GetGDMAChannelx(data->dma_rx.dma_channel)));
+				dma_resume(data->dma_rx.dma_dev, data->dma_rx.dma_channel);
 #endif
 
-			/* Start the RX timer not null */
+				/* Start the RX timer not null */
+				UART_INTConfig(uart, UART_INT_RX_IDLE, DISABLE);
+				UART_INTConfig(uart, UART_INT_RX_IDLE, ENABLE);
+				async_timer_start(&data->dma_rx.timeout_work, data->dma_rx.timeout);
+			}
+		} else
+#endif
+		{
 			UART_INTConfig(uart, UART_INT_RX_IDLE, DISABLE);
 			UART_INTConfig(uart, UART_INT_RX_IDLE, ENABLE);
-			async_timer_start(&data->dma_rx.timeout_work, data->dma_rx.timeout);
+#ifdef CONFIG_UART_RTL87X2G_KEEP_ACTIVE_AFTER_RX_WAKEUP
+			data->uart_pm_check_state_idle = RTL87X2G_PM_CHECK_PASS;
+#endif
 		}
 	}
 
+#ifdef CONFIG_UART_ASYNC_API
 	/* Clear errors */
 	uart_rtl87x2g_err_check(dev);
 #endif /* CONFIG_UART_ASYNC_API */
+
 #if DBG_DIRECT_SHOW
 	DBG_DIRECT("[%s] exit", __func__);
 #endif
@@ -1134,6 +1177,39 @@ static void uart_rtl87x2g_isr(const struct device *dev)
 #endif /* CONFIG_UART_INTERRUPT_DRIVEN || CONFIG_UART_ASYNC_API */
 
 #ifdef CONFIG_PM_DEVICE
+
+#if CONFIG_UART_RTL87X2G_KEEP_ACTIVE_AFTER_RX_WAKEUP
+static RTL87X2G_PM_CHECK_RET uart_pm_check(void)
+{
+	RTL87X2G_PM_CHECK_RET ret = RTL87X2G_PM_CHECK_FAIL;
+	struct uart_rtl87x2g_data *data;
+
+	if (uart_pm_check_state_timeout == RTL87X2G_PM_CHECK_PASS) {
+		for (int i = 0; i < ARRAY_SIZE(devices); i++) {
+			data = (struct uart_rtl87x2g_data *)(devices[i]->data);
+			if (data->uart_pm_check_state_idle == RTL87X2G_PM_CHECK_FAIL) {
+				goto check_ret;
+			}
+		}
+		ret = RTL87X2G_PM_CHECK_PASS;
+	}
+check_ret:
+	return ret;
+}
+
+static void uart_register_dlps_cb(void)
+{
+	platform_pm_register_callback_func_with_priority((void *)uart_pm_check, PLATFORM_PM_CHECK,
+							 1);
+}
+
+static void uart_rx_wakeup_timer_cb(struct k_timer *timer)
+{
+	k_timer_stop(&uart_rx_wakeup_timer);
+	uart_pm_check_state_timeout = RTL87X2G_PM_CHECK_PASS;
+}
+#endif
+
 static int uart_rtl87x2g_pm_action(const struct device *dev, enum pm_device_action action)
 {
 	const struct uart_rtl87x2g_config *config = dev->config;
@@ -1156,6 +1232,26 @@ static int uart_rtl87x2g_pm_action(const struct device *dev, enum pm_device_acti
 		}
 		break;
 	case PM_DEVICE_ACTION_RESUME:
+		(void)clock_control_on(RTL87X2G_CLOCK_CONTROLLER,
+				       (clock_control_subsys_t)&config->clkid);
+
+#if CONFIG_UART_RTL87X2G_KEEP_ACTIVE_AFTER_RX_WAKEUP
+		const struct pinctrl_state *state;
+
+		err = pinctrl_lookup_state(config->pcfg, PINCTRL_STATE_SLEEP, &state);
+		if (err == 0) {
+			for (uint8_t i = 0U; i < state->pin_cnt; i++) {
+				if (state->pins[i].wakeup_low &&
+				    System_WakeUpInterruptValue(state->pins[i].pin)) {
+					uart_pm_check_state_timeout = RTL87X2G_PM_CHECK_FAIL;
+					k_timer_start(
+						&uart_rx_wakeup_timer,
+						K_MSEC(CONFIG_UART_RTL87X2G_KEEP_ACTIVE_MSEC),
+						K_FOREVER);
+				}
+			}
+		}
+#endif
 		/* Set pins to active state */
 		err = pinctrl_apply_state(config->pcfg, PINCTRL_STATE_DEFAULT);
 		if (err < 0) {
@@ -1255,6 +1351,10 @@ static int uart_rtl87x2g_init(const struct device *dev)
 		return err;
 	}
 
+#if CONFIG_UART_RTL87X2G_KEEP_ACTIVE_AFTER_RX_WAKEUP
+	data->uart_pm_check_state_idle = RTL87X2G_PM_CHECK_PASS;
+	uart_register_dlps_cb();
+#endif
 	/* Enable nvic */
 #if defined(CONFIG_UART_INTERRUPT_DRIVEN) || defined(CONFIG_UART_ASYNC_API)
 	config->irq_config_func(dev);
@@ -1288,6 +1388,7 @@ static int uart_rtl87x2g_init(const struct device *dev)
 			.dest_burst_length = RTL87X2G_DMA_CONFIG_DESTINATION_MSIZE(                \
 				RTL87X2G_DMA_CHANNEL_CONFIG(index, dir)),                          \
 			.block_count = 1,                                                          \
+			.cyclic = false,                                                           \
 			.complete_callback_en = 1,                                                 \
 			.dma_callback = uart_rtl87x2g_dma_##dir##_cb,                              \
 	},                                                                                         \

--- a/drivers/serial/uart_rtl87x2g.h
+++ b/drivers/serial/uart_rtl87x2g.h
@@ -1,5 +1,5 @@
 /*
- * Copyright(c) 2020, Realtek Semiconductor Corporation.
+ * Copyright(c) 2025, Realtek Semiconductor Corporation.
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -14,7 +14,21 @@
 
 #include <zephyr/drivers/pinctrl.h>
 #include <zephyr/drivers/uart.h>
+
 #include <rtl_uart.h>
+
+#ifdef CONFIG_UART_RTL87X2G_KEEP_ACTIVE_AFTER_RX_WAKEUP
+#include <rtl_pinmux.h>
+#include <pm.h>
+#include "power_manager_unit_platform.h"
+#define RTL87X2G_PM_CHECK_PASS PM_CHECK_PASS
+#define RTL87X2G_PM_CHECK_FAIL PM_CHECK_FAIL
+#define RTL87X2G_PM_CHECK_RET  PMCheckResult
+#endif
+
+#ifdef CONFIG_UART_ASYNC_API
+#include <zephyr/drivers/dma.h>
+#endif
 
 struct uart_rtl87x2g_config {
 	UART_TypeDef *uart;
@@ -65,6 +79,9 @@ struct uart_rtl87x2g_data {
 	size_t rx_next_buffer_len;
 #endif
 #ifdef CONFIG_PM_DEVICE
+#ifdef CONFIG_UART_RTL87X2G_KEEP_ACTIVE_AFTER_RX_WAKEUP
+	RTL87X2G_PM_CHECK_RET uart_pm_check_state_idle;
+#endif
 	UARTStoreReg_Typedef store_buf;
 #endif
 };

--- a/modules/Kconfig.realtek
+++ b/modules/Kconfig.realtek
@@ -39,6 +39,16 @@ config USE_HAL_REALTEK_I2C
 	help
 	  Enable HAL REALTEK I2C driver
 
+config USE_HAL_REALTEK_I2S
+	bool
+	help
+	  Enable HAL REALTEK I2S driver
+
+config USE_HAL_REALTEK_CODEC
+	bool
+	help
+	  Enable HAL REALTEK CODEC driver
+
 config USE_HAL_REALTEK_KEYSCAN
 	bool
 	help
@@ -47,7 +57,12 @@ config USE_HAL_REALTEK_KEYSCAN
 config USE_HAL_REALTEK_AON_QDEC
 	bool
 	help
-	  Enable HAL REALTEK AON QDEC driver
+	  Enable HAL REALTEK AON_QDEC driver
+
+config USE_HAL_REALTEK_QDEC
+	bool
+	help
+	  Enable HAL REALTEK QDEC driver
 
 config USE_HAL_REALTEK_UART
 	bool
@@ -58,6 +73,16 @@ config USE_HAL_REALTEK_SPI
 	bool
 	help
 	  Enable HAL REALTEK SPI driver
+
+config USE_HAL_REALTEK_IR
+	bool
+	help
+	  Enable HAL REALTEK IR driver
+
+config USE_HAL_REALTEK_CAN
+	bool
+	help
+	  Enable HAL REALTEK CAN driver
 
 config USE_HAL_REALTEK_USB
 	bool

--- a/soc/arm/realtek_bee/rtl87x2g/power.c
+++ b/soc/arm/realtek_bee/rtl87x2g/power.c
@@ -28,6 +28,7 @@ extern void Pinmux_DLPSEnter(void *PeriReg, void *StoreBuf);
 extern void Pinmux_DLPSExit(void *PeriReg, void *StoreBuf);
 extern void NMI_Handler(void);
 extern void sys_clock_announce_process_timeout(void);
+extern void pad_short_pulse_wake_up(int Status);
 
 volatile uint32_t CPU_StoreReg[6];
 volatile uint8_t CPU_StoreReg_IPR[96];
@@ -123,6 +124,9 @@ static size_t num_susp_rtk;
 
 static int pm_suspend_devices_rtk(void)
 {
+	pad_short_pulse_wake_up(1);
+	Pad_ClearAllWakeupINT();
+	System_WakeupDebounceClear(0);
 	CPU_DLPS_Enter();
 
 	Pinmux_DLPSEnter(PINMUX, (void *)&Pinmux_StoreReg);


### PR DESCRIPTION
1.Add CONFIG_UART_RTL87X2G_KEEP_ACTIVE_AFTER_RX_WAKEUP to avoid enterring dlps and keep active after uart rx wakeup to receive data. If CONFIG_UART_RTL87X2G_KEEP_ACTIVE_AFTER_RX_WAKEUP=y, uart will not allow to enter dlps until timeout and uart_idle;
2.enable short pulse wakeup in power.c;