### PR TITLE
drivers: kscan: change kscan pm flow

### DIFF
--- a/drivers/input/Kconfig.bee_kscan
+++ b/drivers/input/Kconfig.bee_kscan
@@ -37,11 +37,19 @@ config BEE_INPUT_KSCAN_AUTOSCAN_MODE
 	  default is autoscan, else is manual scan.
 
 if !BEE_INPUT_KSCAN_AUTOSCAN_MODE
-config BEE_INPUT_KSCAN_MANUAL_SCAN_INTERVAL_MSEC
-	int "Scan Interval when using manual mode"
-	default 50
+config BEE_INPUT_KSCAN_RELEASE_WAKEUP
+	bool "Wakeup system when key release"
+	default n
 	help
-	  Scan Interval when using manual mode.
+	  Wakeup system when key release using manual mode.
+	  If enabled, When entering DLPS during pressing the key, the row pins
+	  will be configured as pull-up. This results in leakage current through
+	  the pull-up resistor during key press, but the system will wake up
+	  immediately after releasing the key.
+	  If disabled, When entering DLPS by pressing the key, the row pins will
+	  be configured as pull-down. This eliminates leakage current during key
+	  press, but the system can only wake up after a timeout period once the
+	  key is released, followed by a scan to detect key status.
 
 endif # BEE_INPUT_KSCAN_AUTOSCAN_MODE
 

--- a/drivers/input/input_bee_kscan.c
+++ b/drivers/input/input_bee_kscan.c
@@ -52,10 +52,12 @@ extern void (*platform_pm_register_callback_func_with_priority)(void *cb_func,
 
 #if defined(CONFIG_SOC_SERIES_RTL87X2G)
 #define BEE_Pad_SetControlMode(pad, mode)            Pad_SetControlMode(pad, mode)
+#define BEE_Pad_SetPullMode(pad, pull)               Pad_SetPullMode(pad, pull)
 #define BEE_System_WakeUpPinEnable(pin, pol, deb_en) System_WakeUpPinEnable(pin, pol, deb_en)
 #define BEE_KSCAN_REG_CLKDIV                         KEYSCAN_CLK_DIV
 #elif defined(CONFIG_SOC_SERIES_RTL8752H)
 #define BEE_Pad_SetControlMode(pad, mode)            Pad_ControlSelectValue(pad, mode)
+#define BEE_Pad_SetPullMode(pad, pull)               Pad_PullUpOrDownValue(pad, pull)
 #define BEE_System_WakeUpPinEnable(pin, pol, deb_en) System_WakeUpPinEnable(pin, pol, deb_en, 0)
 #define BEE_KSCAN_REG_CLKDIV                         CLKDIV
 #endif
@@ -96,14 +98,17 @@ struct kscan_bee_data {
 	 * new_key_map[j] setting to 1 means row[i] col[j] is pressed.
 	 */
 	uint32_t key_map[CONFIG_BEE_INPUT_KSCAN_MAX_ROW_SIZE];
+	/* Total number of pressed pins before software debounce */
+	uint8_t last_scanned_num;
 	/* Total number of pressed pins after software debounce */
-	uint8_t press_num;
+	uint8_t last_pressed_num;
 	/* To count several scan for software debounce */
 	uint8_t sw_deb_press_cnt;
 	/* Row of pins to configure wakeup pins */
 	uint16_t press_rows;
-#ifdef CONFIG_PM_DEVICE
-	KEYSCANStoreReg_Typedef store_buf;
+#if !CONFIG_BEE_INPUT_KSCAN_AUTOSCAN_MODE
+	/* If timer started, do not configure auto scan during resume */
+	bool timer_started;
 #endif
 };
 
@@ -225,7 +230,7 @@ static void kscan_bee_all_release_process(const struct device *dev)
 #endif
 	data->sw_deb_press_cnt = 0;
 
-	for (uint8_t i = 0; i < data->press_num; i++) {
+	for (uint8_t i = 0; i < data->last_pressed_num; i++) {
 		uint8_t old_row = data->keys[i].row;
 		uint8_t old_col = data->keys[i].column;
 
@@ -234,7 +239,8 @@ static void kscan_bee_all_release_process(const struct device *dev)
 		input_report_key(dev, INPUT_BTN_TOUCH, false, true, K_FOREVER);
 	}
 
-	data->press_num = 0;
+	data->last_scanned_num = 0;
+	data->last_pressed_num = 0;
 	data->all_release_flag = true;
 
 	memset(data->keys, 0, sizeof(data->keys));
@@ -292,7 +298,8 @@ static void kscan_bee_process(const struct device *dev, uint8_t new_press_num,
 		data->all_release_flag = false;
 	}
 
-	if (!memcmp(data->last_keys, new_keys, sizeof(data->last_keys))) {
+	if (memcmp(data->last_keys, new_keys, sizeof(data->last_keys)) == 0 &&
+	    new_press_num == data->last_scanned_num) {
 		/* new_keys is same as last_keys */
 		if (data->sw_deb_press_cnt >= scan_debounce_cnt) {
 			/* after sofeware debounce */
@@ -306,12 +313,11 @@ static void kscan_bee_process(const struct device *dev, uint8_t new_press_num,
 		/* new_keys is different from last_keys, start a new software debounce */
 		data->sw_deb_press_cnt = 0;
 		memcpy(data->last_keys, new_keys, sizeof(data->last_keys));
+		data->last_scanned_num = new_press_num;
 #if !CONFIG_BEE_INPUT_KSCAN_AUTOSCAN_MODE
 		data->press_rows = 0;
 		for (uint8_t i = 0; i < new_press_num; i++) {
-			if (new_keys[i].row) {
-				data->press_rows |= BIT(new_keys[i].row);
-			}
+			data->press_rows |= BIT(new_keys[i].row);
 		}
 #endif
 		goto start_timer;
@@ -322,7 +328,7 @@ static void kscan_bee_process(const struct device *dev, uint8_t new_press_num,
 		/* all key release */
 
 		/* call all cbs for released keys */
-		for (uint8_t i = 0; i < data->press_num; i++) {
+		for (uint8_t i = 0; i < data->last_pressed_num; i++) {
 			uint8_t old_row = data->keys[i].row;
 			uint8_t old_col = data->keys[i].column;
 
@@ -331,7 +337,7 @@ static void kscan_bee_process(const struct device *dev, uint8_t new_press_num,
 			input_report_key(dev, INPUT_BTN_TOUCH, false, true, K_FOREVER);
 		}
 
-		data->press_num = 0;
+		data->last_pressed_num = 0;
 		data->press_rows = 0;
 		data->all_release_flag = true;
 
@@ -341,6 +347,7 @@ static void kscan_bee_process(const struct device *dev, uint8_t new_press_num,
 
 #if !CONFIG_BEE_INPUT_KSCAN_AUTOSCAN_MODE
 		k_timer_stop(&manual_kscan_timer);
+		data->timer_started = false;
 		(void)clock_control_off(BEE_CLOCK_CONTROLLER,
 					(clock_control_subsys_t)&config->clkid);
 		(void)clock_control_on(BEE_CLOCK_CONTROLLER,
@@ -380,7 +387,7 @@ static void kscan_bee_process(const struct device *dev, uint8_t new_press_num,
 		}
 
 		/* update release keys */
-		for (uint8_t i = 0; i < data->press_num; i++) {
+		for (uint8_t i = 0; i < data->last_pressed_num; i++) {
 			uint8_t old_row = data->keys[i].row;
 			uint8_t old_col = data->keys[i].column;
 
@@ -403,14 +410,14 @@ static void kscan_bee_process(const struct device *dev, uint8_t new_press_num,
 			input_report_key(dev, INPUT_BTN_TOUCH, false, true, K_FOREVER);
 		}
 
+		data->last_pressed_num = new_press_num;
 		memcpy(data->keys, new_keys, sizeof(data->keys));
-		data->press_num = new_press_num;
 	}
 
 start_timer:
 #if !CONFIG_BEE_INPUT_KSCAN_AUTOSCAN_MODE
-	k_timer_start(&manual_kscan_timer, K_MSEC(CONFIG_BEE_INPUT_KSCAN_MANUAL_SCAN_INTERVAL_MSEC),
-		      K_FOREVER);
+	data->timer_started = true;
+	k_timer_start(&manual_kscan_timer, K_USEC(config->scan_us), K_FOREVER);
 #endif
 }
 
@@ -489,12 +496,20 @@ static void pm_suspend_process_press(const struct device *dev)
 				/* invert the wakeup level */
 				if (state->pins[i].wakeup_high) {
 					BEE_Pad_SetControlMode(state->pins[i].pin, PAD_SW_MODE);
+#ifdef CONFIG_BEE_INPUT_KSCAN_RELEASE_WAKEUP
 					BEE_System_WakeUpPinEnable(state->pins[i].pin,
 								   PAD_WAKEUP_POL_LOW, DISABLE);
+#else
+					BEE_Pad_SetPullMode(state->pins[i].pin, PAD_PULL_UP);
+#endif
 				} else if (state->pins[i].wakeup_low) {
 					BEE_Pad_SetControlMode(state->pins[i].pin, PAD_SW_MODE);
+#ifdef CONFIG_BEE_INPUT_KSCAN_RELEASE_WAKEUP
 					BEE_System_WakeUpPinEnable(state->pins[i].pin,
 								   PAD_WAKEUP_POL_HIGH, DISABLE);
+#else
+					BEE_Pad_SetPullMode(state->pins[i].pin, PAD_PULL_DOWN);
+#endif
 				}
 			} else {
 				if (state->pins[i].wakeup_high) {
@@ -551,8 +566,7 @@ static int kscan_bee_pm_action(const struct device *dev, enum pm_device_action a
 		ret = pinctrl_lookup_state(config->pcfg, PINCTRL_STATE_SLEEP, &state);
 		if ((ret < 0) && (ret != -ENOENT)) {
 			/* no kscan wakeup pin is configured */
-			kscan_bee_init_driver(dev, KeyScan_Auto_Scan_Mode, KeyScan_Manual_Sel_Key);
-			return ret;
+			goto exit;
 		}
 
 		/* Set pins to active state */
@@ -569,22 +583,32 @@ static int kscan_bee_pm_action(const struct device *dev, enum pm_device_action a
 				System_WakeUpPinDisable(state->pins[i].pin);
 				if (System_WakeUpInterruptValue(state->pins[i].pin) == SET) {
 					is_pad_wakeup = true;
+					kscan_pm_check_state = PM_CHECK_FAIL;
 					Pad_ClearWakeupINTPendingBit(state->pins[i].pin);
 				}
 			}
 		}
 
+exit:
+		/* Set pins to active state */
+		ret = pinctrl_apply_state(config->pcfg, PINCTRL_STATE_DEFAULT);
+		if (ret < 0) {
+			return ret;
+		}
+
+#if !CONFIG_BEE_KSCAN_AUTOSCAN_MODE
 		if (is_pad_wakeup) {
-			kscan_pm_check_state = PM_CHECK_FAIL;
-#if !CONFIG_BEE_INPUT_KSCAN_AUTOSCAN_MODE
 			kscan_bee_init_driver(dev, KeyScan_Manual_Scan_Mode,
 					      KeyScan_Manual_Sel_Bit);
-#else
-			kscan_bee_init_driver(dev, KeyScan_Auto_Scan_Mode, KeyScan_Manual_Sel_Key);
-#endif
 		} else {
-			kscan_bee_init_driver(dev, KeyScan_Auto_Scan_Mode, KeyScan_Manual_Sel_Key);
+			if (data->timer_started == false) {
+				kscan_bee_init_driver(dev, KeyScan_Auto_Scan_Mode,
+						      KeyScan_Manual_Sel_Key);
+			}
 		}
+#else
+		kscan_bee_init_driver(dev, KeyScan_Auto_Scan_Mode, KeyScan_Manual_Sel_Key);
+#endif
 
 		break;
 	default:

--- a/drivers/kscan/Kconfig.bee
+++ b/drivers/kscan/Kconfig.bee
@@ -38,11 +38,19 @@ config BEE_KSCAN_AUTOSCAN_MODE
 	  default is autoscan, else is manual scan.
 
 if !BEE_KSCAN_AUTOSCAN_MODE
-config BEE_KSCAN_MANUAL_SCAN_INTERVAL_MSEC
-	int "Scan Interval when using manual mode"
-	default 50
+config BEE_KSCAN_RELEASE_WAKEUP
+	bool "Wakeup system when key release"
+	default n
 	help
-	  Scan Interval when using manual mode.
+	  Wakeup system when key release using manual mode.
+	  If enabled, When entering DLPS during pressing the key, the row pins
+	  will be configured as pull-up. This results in leakage current through
+	  the pull-up resistor during key press, but the system will wake up
+	  immediately after releasing the key.
+	  If disabled, When entering DLPS by pressing the key, the row pins will
+	  be configured as pull-down. This eliminates leakage current during key
+	  press, but the system can only wake up after a timeout period once the
+	  key is released, followed by a scan to detect key status.
 
 endif # BEE_KSCAN_AUTOSCAN_MODE
 

--- a/drivers/kscan/kscan_bee.c
+++ b/drivers/kscan/kscan_bee.c
@@ -52,10 +52,12 @@ extern void (*platform_pm_register_callback_func_with_priority)(void *cb_func,
 
 #if defined(CONFIG_SOC_SERIES_RTL87X2G)
 #define BEE_Pad_SetControlMode(pad, mode)            Pad_SetControlMode(pad, mode)
+#define BEE_Pad_SetPullMode(pad, pull)               Pad_SetPullMode(pad, pull)
 #define BEE_System_WakeUpPinEnable(pin, pol, deb_en) System_WakeUpPinEnable(pin, pol, deb_en)
 #define BEE_KSCAN_REG_CLKDIV                         KEYSCAN_CLK_DIV
 #elif defined(CONFIG_SOC_SERIES_RTL8752H)
 #define BEE_Pad_SetControlMode(pad, mode)            Pad_ControlSelectValue(pad, mode)
+#define BEE_Pad_SetPullMode(pad, pull)               Pad_PullUpOrDownValue(pad, pull)
 #define BEE_System_WakeUpPinEnable(pin, pol, deb_en) System_WakeUpPinEnable(pin, pol, deb_en, 0)
 #define BEE_KSCAN_REG_CLKDIV                         CLKDIV
 #endif
@@ -98,19 +100,22 @@ struct kscan_bee_data {
 	 * new_key_map[j] setting to 1 means row[i] col[j] is pressed.
 	 */
 	uint32_t key_map[CONFIG_BEE_KSCAN_MAX_ROW_SIZE];
+	/* Total number of pressed pins before software debounce */
+	uint8_t last_scanned_num;
 	/* Total number of pressed pins after software debounce */
-	uint8_t press_num;
+	uint8_t last_pressed_num;
 	/* To count several scan for software debounce */
 	uint8_t sw_deb_press_cnt;
 	/* Row of pins to configure wakeup pins */
 	uint16_t press_rows;
-#ifdef CONFIG_PM_DEVICE
-	KEYSCANStoreReg_Typedef store_buf;
+#if !CONFIG_BEE_KSCAN_AUTOSCAN_MODE
+	/* If timer started, do not configure auto scan during resume */
+	bool timer_started;
 #endif
 };
 
 #ifdef CONFIG_PM_DEVICE
-static PMCheckResult kscan_pm_check_state = PM_CHECK_PASS;
+static volatile PMCheckResult kscan_pm_check_state = PM_CHECK_PASS;
 #endif
 
 static int kscan_bee_init_driver(const struct device *dev, uint32_t scanmode, uint32_t manual_sel)
@@ -261,7 +266,7 @@ static void kscan_bee_all_release_process(const struct device *dev)
 #endif
 	data->sw_deb_press_cnt = 0;
 
-	for (uint8_t i = 0; i < data->press_num; i++) {
+	for (uint8_t i = 0; i < data->last_pressed_num; i++) {
 		uint8_t old_row = data->keys[i].row;
 		uint8_t old_col = data->keys[i].column;
 
@@ -270,7 +275,8 @@ static void kscan_bee_all_release_process(const struct device *dev)
 		}
 	}
 
-	data->press_num = 0;
+	data->last_scanned_num = 0;
+	data->last_pressed_num = 0;
 	data->all_release_flag = true;
 
 	memset(data->keys, 0, sizeof(data->keys));
@@ -329,7 +335,8 @@ static void kscan_bee_process(const struct device *dev, uint8_t new_press_num,
 		data->all_release_flag = false;
 	}
 
-	if (!memcmp(data->last_keys, new_keys, sizeof(data->last_keys))) {
+	if (memcmp(data->last_keys, new_keys, sizeof(data->last_keys)) == 0 &&
+	    new_press_num == data->last_scanned_num) {
 		/* new_keys is same as last_keys */
 		if (data->sw_deb_press_cnt >= scan_debounce_cnt) {
 			/* after sofeware debounce */
@@ -343,12 +350,11 @@ static void kscan_bee_process(const struct device *dev, uint8_t new_press_num,
 		/* new_keys is different from last_keys, start a new software debounce */
 		data->sw_deb_press_cnt = 0;
 		memcpy(data->last_keys, new_keys, sizeof(data->last_keys));
+		data->last_scanned_num = new_press_num;
 #if !CONFIG_BEE_KSCAN_AUTOSCAN_MODE
 		data->press_rows = 0;
 		for (uint8_t i = 0; i < new_press_num; i++) {
-			if (new_keys[i].row) {
-				data->press_rows |= BIT(new_keys[i].row);
-			}
+			data->press_rows |= BIT(new_keys[i].row);
 		}
 #endif
 		goto start_timer;
@@ -359,7 +365,7 @@ static void kscan_bee_process(const struct device *dev, uint8_t new_press_num,
 		/* all key release */
 
 		/* call all cbs for released keys */
-		for (uint8_t i = 0; i < data->press_num; i++) {
+		for (uint8_t i = 0; i < data->last_pressed_num; i++) {
 			uint8_t old_row = data->keys[i].row;
 			uint8_t old_col = data->keys[i].column;
 
@@ -368,7 +374,7 @@ static void kscan_bee_process(const struct device *dev, uint8_t new_press_num,
 			}
 		}
 
-		data->press_num = 0;
+		data->last_pressed_num = 0;
 		data->press_rows = 0;
 		data->all_release_flag = true;
 
@@ -378,6 +384,7 @@ static void kscan_bee_process(const struct device *dev, uint8_t new_press_num,
 
 #if !CONFIG_BEE_KSCAN_AUTOSCAN_MODE
 		k_timer_stop(&manual_kscan_timer);
+		data->timer_started = false;
 		(void)clock_control_off(BEE_CLOCK_CONTROLLER,
 					(clock_control_subsys_t)&config->clkid);
 		(void)clock_control_on(BEE_CLOCK_CONTROLLER,
@@ -417,7 +424,7 @@ static void kscan_bee_process(const struct device *dev, uint8_t new_press_num,
 		}
 
 		/* update release keys */
-		for (uint8_t i = 0; i < data->press_num; i++) {
+		for (uint8_t i = 0; i < data->last_pressed_num; i++) {
 			uint8_t old_row = data->keys[i].row;
 			uint8_t old_col = data->keys[i].column;
 
@@ -440,14 +447,14 @@ static void kscan_bee_process(const struct device *dev, uint8_t new_press_num,
 			}
 		}
 
+		data->last_pressed_num = new_press_num;
 		memcpy(data->keys, new_keys, sizeof(data->keys));
-		data->press_num = new_press_num;
 	}
 
 start_timer:
 #if !CONFIG_BEE_KSCAN_AUTOSCAN_MODE
-	k_timer_start(&manual_kscan_timer, K_MSEC(CONFIG_BEE_KSCAN_MANUAL_SCAN_INTERVAL_MSEC),
-		      K_FOREVER);
+	data->timer_started = true;
+	k_timer_start(&manual_kscan_timer, K_USEC(config->scan_us), K_FOREVER);
 #endif
 }
 
@@ -526,12 +533,20 @@ static void pm_suspend_process_press(const struct device *dev)
 				/* invert the wakeup level */
 				if (state->pins[i].wakeup_high) {
 					BEE_Pad_SetControlMode(state->pins[i].pin, PAD_SW_MODE);
+#ifdef CONFIG_BEE_KSCAN_RELEASE_WAKEUP
 					BEE_System_WakeUpPinEnable(state->pins[i].pin,
 								   PAD_WAKEUP_POL_LOW, DISABLE);
+#else
+					BEE_Pad_SetPullMode(state->pins[i].pin, PAD_PULL_UP);
+#endif
 				} else if (state->pins[i].wakeup_low) {
 					BEE_Pad_SetControlMode(state->pins[i].pin, PAD_SW_MODE);
+#ifdef CONFIG_BEE_KSCAN_RELEASE_WAKEUP
 					BEE_System_WakeUpPinEnable(state->pins[i].pin,
 								   PAD_WAKEUP_POL_HIGH, DISABLE);
+#else
+					BEE_Pad_SetPullMode(state->pins[i].pin, PAD_PULL_DOWN);
+#endif
 				}
 			} else {
 				if (state->pins[i].wakeup_high) {
@@ -588,14 +603,7 @@ static int kscan_bee_pm_action(const struct device *dev, enum pm_device_action a
 		ret = pinctrl_lookup_state(config->pcfg, PINCTRL_STATE_SLEEP, &state);
 		if ((ret < 0) && (ret != -ENOENT)) {
 			/* no kscan wakeup pin is configured */
-			kscan_bee_init_driver(dev, KeyScan_Auto_Scan_Mode, KeyScan_Manual_Sel_Key);
-			return ret;
-		}
-
-		/* Set pins to active state */
-		ret = pinctrl_apply_state(config->pcfg, PINCTRL_STATE_DEFAULT);
-		if (ret < 0) {
-			return ret;
+			goto exit;
 		}
 
 		/* there are kscan wakeup pins configured, check if they wakeup the system
@@ -606,22 +614,32 @@ static int kscan_bee_pm_action(const struct device *dev, enum pm_device_action a
 				System_WakeUpPinDisable(state->pins[i].pin);
 				if (System_WakeUpInterruptValue(state->pins[i].pin) == SET) {
 					is_pad_wakeup = true;
+					kscan_pm_check_state = PM_CHECK_FAIL;
 					Pad_ClearWakeupINTPendingBit(state->pins[i].pin);
 				}
 			}
 		}
 
-		if (is_pad_wakeup) {
-			kscan_pm_check_state = PM_CHECK_FAIL;
+exit:
+		/* Set pins to active state */
+		ret = pinctrl_apply_state(config->pcfg, PINCTRL_STATE_DEFAULT);
+		if (ret < 0) {
+			return ret;
+		}
+
 #if !CONFIG_BEE_KSCAN_AUTOSCAN_MODE
+		if (is_pad_wakeup) {
 			kscan_bee_init_driver(dev, KeyScan_Manual_Scan_Mode,
 					      KeyScan_Manual_Sel_Bit);
-#else
-			kscan_bee_init_driver(dev, KeyScan_Auto_Scan_Mode, KeyScan_Manual_Sel_Key);
-#endif
 		} else {
-			kscan_bee_init_driver(dev, KeyScan_Auto_Scan_Mode, KeyScan_Manual_Sel_Key);
+			if (data->timer_started == false) {
+				kscan_bee_init_driver(dev, KeyScan_Auto_Scan_Mode,
+						      KeyScan_Manual_Sel_Key);
+			}
 		}
+#else
+		kscan_bee_init_driver(dev, KeyScan_Auto_Scan_Mode, KeyScan_Manual_Sel_Key);
+#endif
 
 		break;
 	default:

--- a/soc/realtek/bee/rtl8752h/power.c
+++ b/soc/realtek/bee/rtl8752h/power.c
@@ -119,18 +119,6 @@ void System_Handler(const void *param)
 	irq_disable(System_IRQn);
 	POWER_LOG("System_Handler");
 
-	if (System_WakeUpInterruptValue(P0_1) == SET) {
-		POWER_LOG("P0_1");
-		Pad_ClearWakeupINTPendingBit(P0_1);
-		System_WakeUpPinDisable(P0_1);
-		/* allowedSystemEnterDlps = false; */
-	}
-	if (System_WakeUpInterruptValue(P2_4) == SET) {
-		POWER_LOG("P2_4");
-		Pad_ClearWakeupINTPendingBit(P2_4);
-		/* avoid retrigger? */
-		System_WakeUpPinDisable(P2_4);
-	}
 	NVIC_ClearPendingIRQ(System_IRQn);
 }
 
@@ -158,11 +146,11 @@ static size_t num_susp_rtk;
 
 static int pm_suspend_devices_rtk(void)
 {
+	Pad_ClearAllWakeupINT();
 	CPU_DLPS_Enter();
 
 	/* Realtek PM Device flow */
 	irq_disable(System_IRQn);
-	Pinmux_DLPS_Enter();
 	/* common flow */
 	const struct device *devs;
 	size_t devc;
@@ -202,7 +190,6 @@ static int pm_suspend_devices_rtk(void)
 void pm_resume_devices_rtk(void)
 {
 	/* Realtek PM Device flow */
-	Pinmux_DLPS_Exit();
 	irq_enable(System_IRQn);
 	/* common flow */
 	for (int i = (num_susp_rtk - 1); i >= 0; i--) {


### PR DESCRIPTION
1.Check wakeup status firstly then configure pinctrl to avoid level change during pinctrl config which leads to undesired wakeup bit.
2.If [0,0] is pressed first time the current key check condition will jump to "same key" condition by mistake, and will not set the related bit for row0. Modify the key check condition.
3.Remove pinmux store/restore in power.c because each driver has pinctrl  suspend/resume flow.
4.Clear all pad wakeup bit before entering dlps to avoid undesired  wakeup.
5.Do nothing in system handler to avoid undesired wakeup bit clear.
6.Add CONFIG_BEE_KSCAN_RELEASE_WAKEUP for pressed key pull configure.
7.Do not configure auto scan if sw timer is active.