### PR TITLE
dts: rtl87x2g: rename deprecated properties

### DIFF
--- a/dts/arm/realtek/rtl87x2g.dtsi
+++ b/dts/arm/realtek/rtl87x2g.dtsi
@@ -509,7 +509,7 @@
 			reg = <0x40038000 0x34c>;
 			interrupts = <72 1>;
 			clocks = <&cctl APB_CLK(A2C)>;
-			bus-speed = <500000>;
+			bitrate = <500000>;
 			sample-point = <875>;
 			status = "disabled";
 		};


### PR DESCRIPTION
Rename bus-speed to bitrate for can driver to fix build warning.