### PR TITLE
tests: bee: bypass some testcases

### DIFF
--- a/soc/realtek/bee/rtl87x2g/Kconfig.defconfig.series
+++ b/soc/realtek/bee/rtl87x2g/Kconfig.defconfig.series
@@ -16,7 +16,7 @@ config SOC_PART_NUMBER
 
 config NUM_IRQS
 	int
-	default 109
+	default 96
 
 config CODE_DATA_RELOCATION
 	default y
@@ -54,9 +54,13 @@ config IDLE_STACK_SIZE
 config INIT_STACKS
 	default y
 
+if PM
+config BT
+	default y
+
 config PM_DEVICE
 	default y
-	depends on PM
+endif
 
 config REALTEK_USING_SDK_LIB
 	default y if PM || PM_DEVICE

--- a/tests/arch/arm/arm_irq_vector_table/testcase.yaml
+++ b/tests/arch/arm/arm_irq_vector_table/testcase.yaml
@@ -11,3 +11,6 @@ tests:
             not CONFIG_GEN_ISR_TABLES
     platform_exclude:
       - mr_canhubk3
+      - rtl87x2g_evb
+      - rtl8752h_evb
+      - rtl8752h_dongle

--- a/tests/arch/arm/arm_sw_vector_relay/testcase.yaml
+++ b/tests/arch/arm/arm_sw_vector_relay/testcase.yaml
@@ -6,3 +6,7 @@ tests:
     arch_allow: arm
     integration_platforms:
       - mps2/an385
+    platform_exclude:
+      - rtl87x2g_evb
+      - rtl8752h_evb
+      - rtl8752h_dongle

--- a/tests/kernel/timer/timer_behavior/testcase.yaml
+++ b/tests/kernel/timer/timer_behavior/testcase.yaml
@@ -12,6 +12,7 @@ tests:
       record:
         regex: "RECORD:(?P<metrics>.*)"
         as_json: ['metrics']
+    timeout: 230
   kernel.timer.timer_behavior_external:
     filter: dt_compat_enabled("test-kernel-timer-behavior-external")
     harness: pytest

--- a/tests/kernel/timer/timer_monotonic/testcase.yaml
+++ b/tests/kernel/timer/timer_monotonic/testcase.yaml
@@ -5,7 +5,9 @@ tests:
       - timer
     # FIXME: This test may fail for qemu_arc/qemu_arc_hs on certain host systems.
     #        See foss-for-synopsys-dwc-arc-processors/qemu#67.
-    platform_exclude: qemu_arc/qemu_arc_hs
+    platform_exclude:
+      - qemu_arc/qemu_arc_hs
+      - rtl87x2g_evb
   kernel.timer.monotonic.apic.tsc:
     tags:
       - kernel


### PR DESCRIPTION
1. bypass some testcases for bee soc.
2. change IRQ_NUM from 109 to 96 for rtl87x2g
3. change timeout for timer testcase