### PR TITLE
tests: drivers: rtl8752h_evb: require higher stack size

### DIFF
--- a/tests/drivers/flash/common/boards/rtl8752h_evb.conf
+++ b/tests/drivers/flash/common/boards/rtl8752h_evb.conf
@@ -1,0 +1,4 @@
+# Copyright(c) 2025, Realtek Semiconductor Corporation.
+# SPDX-License-Identifier: Apache-2.0
+
+CONFIG_MAIN_STACK_SIZE=4096

--- a/tests/drivers/flash/common/testcase.yaml
+++ b/tests/drivers/flash/common/testcase.yaml
@@ -101,3 +101,8 @@ tests:
       - gd32vf103v_eval
       - gd32a503v_eval
       - gd32f470i_eval
+  drivers.flash.common.rtl:
+    platform_allow:
+      - rtl8752h_evb
+    extra_args:
+      - OVERLAY_CONFIG=boards/rtl8752h_evb.conf


### PR DESCRIPTION
Increasing the stack size to pass the
tests/drivers/flash testcase on the rtl8752h_evb.