### PR TITLE
soc: rtl8752h: move rtk_platform_init_stage_2 to PRE_KERNEL stage

### DIFF
--- a/soc/realtek/bee/rtl8752h/soc.c
+++ b/soc/realtek/bee/rtl8752h/soc.c
@@ -235,7 +235,7 @@ static int rtk_platform_init_stage_1(void)
 	return 0;
 }
 
-static int rtk_platform_init_stage_2(void)
+int rtk_platform_init_stage_2(void)
 {
 	platform_rtc_aon_init();
 
@@ -290,4 +290,4 @@ static int rtk_register_update(void)
 
 SYS_INIT(rtk_platform_init_stage_1, EARLY, 0);
 SYS_INIT(rtk_register_update, PRE_KERNEL_2, 1);
-SYS_INIT(rtk_platform_init_stage_2, APPLICATION, 0);
+SYS_INIT(rtk_platform_init_stage_2, PRE_KERNEL_2, 2);


### PR DESCRIPTION
For the case that call sleep in POST_KERNEL stage, if rtk_platform_init_stage_2 is not finished, it will cause fault in IDLE task, such as dlps check function.

And the POST_KERNEL stage means kernel functions already available. So i put the rtk_platform_init_stage_2 to PRE_KERNEL stage 👨‍🌾 . 