### PR TITLE
soc: rtl8752h: add check in irq restore

### DIFF
--- a/soc/realtek/bee/rtl8752h/soc.c
+++ b/soc/realtek/bee/rtl8752h/soc.c
@@ -107,6 +107,9 @@ static void restore_isr_registered_in_zephyr(void)
 		isr_handler = RamVectorTable[(uint32_t)vector_n];
 		if (isr_handler != (ISR_HANDLER)_isr_wrapper) {
 			irqn = vector_n - 16;
+			if (_sw_isr_table[irqn].isr == isr_handler) {
+				continue;
+			}
 			if (irq_is_enabled(irqn)) {
 				irq_disable(irqn);
 				z_isr_install(irqn, isr_handler, NULL);

--- a/soc/realtek/bee/rtl8752h/soc.c
+++ b/soc/realtek/bee/rtl8752h/soc.c
@@ -107,16 +107,17 @@ static void restore_isr_registered_in_zephyr(void)
 		isr_handler = RamVectorTable[(uint32_t)vector_n];
 		if (isr_handler != (ISR_HANDLER)_isr_wrapper) {
 			irqn = vector_n - 16;
-			if (_sw_isr_table[irqn].isr == isr_handler) {
-				continue;
-			}
 			if (irq_is_enabled(irqn)) {
 				irq_disable(irqn);
-				z_isr_install(irqn, isr_handler, NULL);
+				if (_sw_isr_table[irqn].isr != isr_handler) {
+					z_isr_install(irqn, isr_handler, NULL);
+				}
 				RamVectorTableUpdate(vector_n, (IRQ_Fun)_isr_wrapper);
 				irq_enable(irqn);
 			} else {
-				z_isr_install(irqn, isr_handler, NULL);
+				if (_sw_isr_table[irqn].isr != isr_handler) {
+					z_isr_install(irqn, isr_handler, NULL);
+				}
 				RamVectorTableUpdate(vector_n, (IRQ_Fun)_isr_wrapper);
 			}
 			DBG_DIRECT("Restore ISR registered in SYS_INIT: vector_n:%d irqn:%d "

--- a/subsys/testsuite/include/zephyr/interrupt_util.h
+++ b/subsys/testsuite/include/zephyr/interrupt_util.h
@@ -39,6 +39,18 @@ static inline uint32_t get_available_nvic_line(uint32_t initial_offset)
 				NVIC_ClearPendingIRQ(i);
 
 				if (!NVIC_GetPendingIRQ(i)) {
+#if defined(CONFIG_SOC_FAMILY_REALTEK_BEE)
+#if defined(CONFIG_GEN_SW_ISR_TABLE)
+					/*
+					 * For interrupts where the IRQ is not enabled but an ISR
+					 * has been installed, such IRQ should not be considered
+					 * as available IRQs for testing purposes.
+					 */
+					if (_sw_isr_table[i].isr != (void *)z_irq_spurious) {
+						continue;
+					}
+#endif
+#endif
 					/*
 					 * If the NVIC line can be successfully
 					 * un-pended, it is guaranteed that it


### PR DESCRIPTION
If the isr in _sw_isr_table has been same as isr_handler in RamVectorTable, skip it to avoid the possibility of repeated registration.

And this commit fix the arch.shared_interrupt test case.