### PR TITLE
drivers: clock_control: fix CI issue for bee

### DIFF
--- a/drivers/clock_control/clock_control_bee.c
+++ b/drivers/clock_control/clock_control_bee.c
@@ -15,7 +15,7 @@
 #if defined(CONFIG_SOC_SERIES_RTL87X2G)
 #include <rtl_rcc.h>
 #elif defined(CONFIG_SOC_SERIES_RTL8752H)
-#include <rtl876X_rcc.h>
+#include <rtl876x_rcc.h>
 #endif
 
 #include <trace.h>


### PR DESCRIPTION
Modify wrong file name to "rtl876x_rcc.h"