### PR TITLE
rtl8752h: replace nickname with formal name

### DIFF
--- a/soc/realtek/bee/rtl8752h/soc.c
+++ b/soc/realtek/bee/rtl8752h/soc.c
@@ -10,7 +10,7 @@
 #include "trace.h"
 #include <zephyr/init.h>
 #include <zephyr/linker/linker-defs.h>
-#include "bee3plus_rom_defines.h"
+#include "rtl8752h_rom_defines.h"
 #include "mem_config.h"
 #include "mem_types.h"
 #include "os_sched.h"
@@ -201,7 +201,7 @@ static int rtk_platform_init_stage_1(void)
 	if (!aon_boot_done) {
 		pmu_power_on_sequence_restart();
 
-		DBG_DIRECT("Bee3Plus ROM version: %s %s", __DATE__, __TIME__);
+		DBG_DIRECT("rtl8752h ROM version: %s %s", __DATE__, __TIME__);
 
 		/* Pad_ClearAllWakeupINT(); */
 	} else {


### PR DESCRIPTION
change from bee3plus/bee4 to rtl8752h/rtl87x2g

Related:
https://github.com/rtkconnectivity/realtek-zephyr-project/pull/28
https://github.com/rtkconnectivity/hal_realtek/pull/97