### PR TITLE
bee: pm: support rtk pm pend stage

### DIFF
--- a/kernel/timeout.c
+++ b/kernel/timeout.c
@@ -362,12 +362,15 @@ void sys_clock_restore_tick_and_cycle(void)
 	sys_clock_only_add_cycle_count(pended_ticks);
 	/* restore cur_ticks. */
 	curr_tick += pended_ticks;
+}
+
+void sys_clock_announce_process_timeout(void)
+{
+	k_spinlock_key_t key = k_spin_lock(&timeout_lock);
 
 	struct _timeout *t;
 
-	for (t = first();
-	     (t != NULL) && (t->dticks <= pended_ticks);
-	     t = next(t)) {
+	for (t = first(); (t != NULL) && (t->dticks <= pended_ticks); t = next(t)) {
 		int dt = t->dticks;
 
 		t->dticks = 0;
@@ -380,17 +383,12 @@ void sys_clock_restore_tick_and_cycle(void)
 
 	pended_ticks = 0;
 
-}
+	/* Separate the handling of pending tick counts and timeout
+	 * callback functions to avoid errors when a timer is started
+	 * during the timer callback.
+	 */
 
-void sys_clock_announce_process_timeout(void)
-{
-	k_spinlock_key_t key = k_spin_lock(&timeout_lock);
-
-	struct _timeout *t;
-
-	for (t = first();
-	     (t != NULL) && (t->dticks == 0);
-	     t = first()) {
+	for (t = first(); (t != NULL) && (t->dticks == 0); t = first()) {
 		remove_timeout(t);
 
 		k_spin_unlock(&timeout_lock, key);

--- a/soc/realtek/bee/rtl8752h/power.c
+++ b/soc/realtek/bee/rtl8752h/power.c
@@ -15,6 +15,7 @@
 #include <cmsis_core.h>
 #include <dlps.h>
 #include <trace.h>
+#include <os_pm.h>
 #include <rtl876x_pinmux.h>
 #include <zephyr/logging/log.h>
 
@@ -29,6 +30,7 @@ extern void (*platform_pm_register_callback_func_with_priority)(void *cb_func,
 
 extern void NMI_Handler(void);
 extern void sys_clock_announce_process_timeout(void);
+extern void sys_clock_restore_tick_and_cycle(void);
 
 #if REALTEK_POWER_LOG
 #define POWER_LOG(...) DBG_DIRECT(__VA_ARGS__)
@@ -122,25 +124,6 @@ void System_Handler(const void *param)
 	NVIC_ClearPendingIRQ(System_IRQn);
 }
 
-static uint32_t Pinmux_StoreReg[10]; /*  This array should be placed in RAM ON/Buffer ON.    */
-static void Pinmux_DLPS_Enter(void)
-{
-	POWER_LOG("%s is called", __func__);
-	Pad_ControlSelectValue(P3_0, PAD_SW_MODE);
-	Pad_ControlSelectValue(P3_1, PAD_SW_MODE);
-	for (uint8_t i = 0; i < 10; i++) {
-		Pinmux_StoreReg[i] = PINMUX->CFG[i];
-	}
-}
-
-static void Pinmux_DLPS_Exit(void)
-{
-	POWER_LOG("%s is called", __func__);
-	for (uint8_t i = 0; i < 10; i++) {
-		PINMUX->CFG[i] = Pinmux_StoreReg[i];
-	}
-}
-
 /* Number of devices successfully suspended. */
 static size_t num_susp_rtk;
 
@@ -202,41 +185,28 @@ void pm_resume_devices_rtk(void)
 	CPU_DLPS_Exit();
 }
 
-#define RTK_PM_WORKQ_STACK_SIZE 768
-#define RTK_PM_WORKQ_PRIORITY   K_HIGHEST_THREAD_PRIO
-
-K_THREAD_STACK_DEFINE(rtk_pm_workq_stack_area, RTK_PM_WORKQ_STACK_SIZE);
-
-static struct k_work_q rtk_pm_workq;
-static struct k_work work_timeout_process;
-static struct k_work work_device_resume;
-
-void timeout_process_handler(struct k_work *item)
+void pm_reusme_systick_and_process_timeout(void)
 {
-	/* Handle the timeouts that expired during lowpower */
+	/* Restore systick after driver resume to ensure no systick isr is triggered and exclude
+	 * timer is timeout out and executed. Restore the sys clock of Zephyr. Note: exclude timer
+	 * cb may rely on the driver resume.
+	 */
+	__disable_irq();
+	os_pm_restore_tickcount();
+	sys_clock_restore_tick_and_cycle();
+	__enable_irq();
+
+	/* Subtract the pended tick from the timeout list and manually trigger a timeout process.*/
 	sys_clock_announce_process_timeout();
 }
 
-void device_resume_handler(struct k_work *item)
-{
-	pm_resume_devices_rtk();
-}
-
-void pm_work_submit(void)
-{
-	/* To minimize irq_lock time, defer time-consuming resuming and compensation
-	 * operations to be executed by the work queue
-	 */
-	extern void sys_clock_restore_tick_and_cycle(void);
-	sys_clock_restore_tick_and_cycle();
-	k_work_submit_to_queue(&rtk_pm_workq, &work_device_resume);
-	k_work_submit_to_queue(&rtk_pm_workq, &work_timeout_process);
-}
-
 /* Initialize power system */
-static int rtl87x2x_power_init(void)
+static int rtl8752h_power_init(void)
 {
 	int ret = 0;
+
+	os_pm_init();
+
 #ifdef CONFIG_PM_DEVICE
 	irq_connect_dynamic(System_IRQn, 1, System_Handler, NULL, 0);
 	irq_enable(System_IRQn);
@@ -250,25 +220,15 @@ static int rtl87x2x_power_init(void)
 
 	platform_pm_system.stage_time[PLATFORM_PM_EXIT] = 13;
 
-	/* do devices & nvic resume in
-	 * rtk_pm_workq thread via zephyr's workq
-	 */
-	k_work_queue_init(&rtk_pm_workq);
-	k_work_queue_start(&rtk_pm_workq, rtk_pm_workq_stack_area,
-			   K_THREAD_STACK_SIZEOF(rtk_pm_workq_stack_area), RTK_PM_WORKQ_PRIORITY,
-			   NULL);
-	k_work_init(&work_timeout_process, timeout_process_handler);
-	k_work_init(&work_device_resume, device_resume_handler);
-
-	/* register callbacks to PM Store stage */
 	platform_pm_register_callback_func_with_priority((void *)pm_suspend_devices_rtk,
 							 PLATFORM_PM_STORE, 1);
-	/* do pm_work_submit after os_pm_restore(tick restore) */
-	platform_pm_register_callback_func_with_priority((void *)pm_work_submit,
-							 PLATFORM_PM_RESTORE, 2);
+	platform_pm_register_callback_func_with_priority((void *)pm_resume_devices_rtk,
+							 PLATFORM_PM_PEND, -1);
+	platform_pm_register_callback_func_with_priority(
+		(void *)pm_reusme_systick_and_process_timeout, PLATFORM_PM_PEND, INT8_MAX);
 
 	return ret;
 }
 
 /* do it after lowerstack entry */
-SYS_INIT(rtl87x2x_power_init, APPLICATION, 1);
+SYS_INIT(rtl8752h_power_init, APPLICATION, 1);

--- a/soc/realtek/bee/rtl8752h/soc.c
+++ b/soc/realtek/bee/rtl8752h/soc.c
@@ -247,7 +247,6 @@ int rtk_platform_init_stage_2(void)
 	power_manager_master_init();
 	power_manager_slave_init();
 	platform_pm_init();
-	os_pm_init();
 
 	init_osc_sdm_timer();
 

--- a/soc/realtek/bee/rtl87x2g/power.c
+++ b/soc/realtek/bee/rtl87x2g/power.c
@@ -11,6 +11,7 @@
 #include <zephyr/kernel_structs.h>
 #include <zephyr/init.h>
 #include <string.h>
+#include <stdint.h>
 #include <zephyr/drivers/timer/system_timer.h>
 #include <zephyr/pm/device.h>
 #include <zephyr/pm/device_runtime.h>
@@ -25,17 +26,12 @@
 #include <power_manager_unit_platform.h>
 #include <pm.h>
 #include <rtl_pinmux.h>
+#include "os_pm.h"
 #include <trace.h>
 
 #include <zephyr/logging/log.h>
 LOG_MODULE_REGISTER(rtl87x2g_pm, LOG_LEVEL_INF);
 
-#define RTK_PM_WORKQ_STACK_SIZE 768
-#define RTK_PM_WORKQ_PRIORITY   K_HIGHEST_THREAD_PRIO
-
-K_THREAD_STACK_DEFINE(rtk_pm_workq_stack_area, RTK_PM_WORKQ_STACK_SIZE);
-
-struct k_work_q rtk_pm_workq;
 struct k_work work_timeout_process;
 struct k_work work_device_resume;
 
@@ -48,6 +44,7 @@ extern void NMI_Handler(void);
 extern void sys_clock_announce_process_timeout(void);
 extern void pad_short_pulse_wake_up(int Status);
 extern void sys_clock_restore_tick_and_cycle(void);
+extern void os_pm_restore_tickcount(void);
 
 volatile uint32_t CPU_StoreReg[6];
 volatile uint8_t CPU_StoreReg_IPR[96];
@@ -175,28 +172,19 @@ void pm_state_exit_post_ops(enum pm_state state, uint8_t substate_id)
 	ARG_UNUSED(substate_id);
 }
 
-void timeout_process_handler(struct k_work *item)
+void pm_reusme_systick_and_process_timeout(void)
 {
-	sys_clock_announce_process_timeout();
-}
-
-void device_resume_handler(struct k_work *item)
-{
-	pm_resume_devices_rtk();
-}
-
-void submit_items_to_rtk_pm_workq(void)
-{
-/* Restore cur_ticks and cycle_count at this point rather than waiting until
- * work_timeout_process. This is because if you wait until work_timeout_process to
- * restore them, there might be a situation where after restoring nvic in
- * work_device_resume, an interrupt is triggered that enters the isr. At this point, ticks
- * and cycle have not been restored, and if the timing API is called, it will return the
- * values from when entering DLPS.
- */
+	/* Restore systick after driver resume to ensure no systick isr is triggered and exclude
+	 * timer is timeout out and executed. Restore the sys clock of Zephyr. Note: exclude timer
+	 * cb may rely on the driver resume.
+	 */
+	__disable_irq();
+	os_pm_restore_tickcount();
 	sys_clock_restore_tick_and_cycle();
-	k_work_submit_to_queue(&rtk_pm_workq, &work_device_resume);
-	k_work_submit_to_queue(&rtk_pm_workq, &work_timeout_process);
+	__enable_irq();
+
+	/* Subtract the pended tick from the timeout list and manually trigger a timeout process. */
+	sys_clock_announce_process_timeout();
 }
 
 /* Initialize power system */
@@ -204,33 +192,20 @@ static int rtl87x2g_power_init(void)
 {
 	int ret = 0;
 
+	/* Init essential APIs related to OS for RTK PM. */
+	os_pm_init();
+
 	bt_power_mode_set(BTPOWER_DEEP_SLEEP);
 	power_mode_set(POWER_DLPS_MODE);
+
 	z_arm_nmi_set_handler(NMI_Handler);
-	k_work_queue_init(&rtk_pm_workq);
-	k_work_queue_start(&rtk_pm_workq, rtk_pm_workq_stack_area,
-			   K_THREAD_STACK_SIZEOF(rtk_pm_workq_stack_area), RTK_PM_WORKQ_PRIORITY,
-			   NULL);
-	k_work_init(&work_timeout_process, timeout_process_handler);
-	k_work_init(&work_device_resume, device_resume_handler);
+
 	platform_pm_register_callback_func_with_priority((void *)pm_suspend_devices_rtk,
 							 PLATFORM_PM_STORE, 1);
-	/* do timeout function process and devices & nvic resume in
-	 * rtk_pm_workq thread via zephyr's workq mechanism.
-	 */
-	platform_pm_register_callback_func_with_priority((void *)submit_items_to_rtk_pm_workq,
-							 PLATFORM_PM_PEND, 1);
-
-	/* The rtl87x2g Zephyr has not registered platform_pm_system.schedule_bottom_half_callback
-	 * in rtk power manager. Therefore,
-	 * we need to fine-tune platform_pm_system.stage_time[PLATFORM_PM_PEND]. The default value
-	 * is 100 (equivalent to 3.125ms), which is too large,
-	 * causing the system to wake up too early and thereby increasing power consumption.
-	 * In the Zephyr environment, change this default value to 20.
-	 * If the app has additional registered pend functions, consider increasing this value
-	 * accordingly to ensure the system does not oversleep.
-	 */
-	platform_pm_system.stage_time[PLATFORM_PM_PEND] = 20;
+	platform_pm_register_callback_func_with_priority((void *)pm_resume_devices_rtk,
+							 PLATFORM_PM_PEND, -1);
+	platform_pm_register_callback_func_with_priority(
+		(void *)pm_reusme_systick_and_process_timeout, PLATFORM_PM_PEND, INT8_MAX);
 
 	return ret;
 }

--- a/soc/realtek/bee/rtl87x2g/soc.c
+++ b/soc/realtek/bee/rtl87x2g/soc.c
@@ -120,12 +120,14 @@ static void rtl87x2g_isr_register(void)
 static void rtl87x2g_extra_ram_init(void)
 {
 	z_early_memcpy(&__extram_data_start, &__extram_data_load_start,
-			__extram_data_end - __extram_data_start);
+		       __extram_data_end - __extram_data_start);
 	z_early_memset(__extram_bss_start, 0, __extram_bss_end - __extram_bss_start);
 }
 
 static int rtl87x2g_platform_init(void)
 {
+
+	DBG_DIRECT("in here!");
 	rtl87x2g_extra_ram_init();
 	/*
 	 * RTL87X2G reserves a RAM region for the vector table, referred to as the RamVectorTable.
@@ -149,9 +151,6 @@ static int rtl87x2g_platform_init(void)
 
 	/* Init heap using Zephyr heap APIs. */
 	os_init();
-
-	/* Init essential APIs related to OS for RTK PM. */
-	os_pm_init();
 
 	/* TZ enabled: for “Non-secure function call”.
 	 * Init non-secure function pointer that will be called by secure side using
@@ -266,12 +265,12 @@ static int rtl87x2g_update_systick_config(void)
 	NVIC_SetPriority(SysTick_IRQn, 0xff);
 	SysTick->CTRL &= ~SysTick_CTRL_CLKSOURCE_Msk;
 
-/*
- * Unset SCB_CCR_DIV_0_TRP bit to avoid usagefault when dividing by zero.
- * If this bit is set, ll_iso_generate_cis_unframed_parameters_from_host_info()
- * in rom will trigger usage fault.
- * WARNING: In Freertos, this bit will not be set.
- */
+	/*
+	 * Unset SCB_CCR_DIV_0_TRP bit to avoid usagefault when dividing by zero.
+	 * If this bit is set, ll_iso_generate_cis_unframed_parameters_from_host_info()
+	 * in rom will trigger usage fault.
+	 * WARNING: In Freertos, this bit will not be set.
+	 */
 	SCB->CCR &= ~SCB_CCR_DIV_0_TRP_Msk;
 
 	return 0;

--- a/tests/boards/rtl8752h_evb/pm/pad_wakeup_dlps/testcase.yaml
+++ b/tests/boards/rtl8752h_evb/pm/pad_wakeup_dlps/testcase.yaml
@@ -1,6 +1,7 @@
 tests:
   boards.rtl8752h.pm.pad_wakeup_dlps:
     platform_allow:
-      - rtl8752h_evb
+      - rtl8752h_evb/rtl8752htv
+      - rtl8752h_evb/rtl8752hkf
     tags:
       - pm

--- a/tests/boards/rtl8752h_evb/pm/timeout_wakeup/src/main.c
+++ b/tests/boards/rtl8752h_evb/pm/timeout_wakeup/src/main.c
@@ -11,6 +11,11 @@
 #include <dlps.h>
 #include <os_pm.h>
 #include <os_timer.h>
+
+extern void (*platform_pm_register_callback_func_with_priority)(void *cb_func,
+								PlatformPMStage pf_pm_stage,
+								int8_t priority);
+
 struct triggered_test_item {
 	int key;
 	struct k_work_poll work;
@@ -51,7 +56,6 @@ static uint32_t kc_spend_time;
 
 static uint16_t test_exclude_timer_cnt;
 void *test_exclude_timer;
-static struct k_timer test_timer;
 
 static inline void get_start_time_cyc2(void)
 {
@@ -218,7 +222,7 @@ ZTEST(timeout_wakeup, test_timing_apis)
 	zassert_true(wakeup_count_timing_apis == 1, "test_timing_apis failed, wakeup Count: %d\n",
 		     wakeup_count_timing_apis);
 	TC_PRINT("sleep time, ms:%lld, cycle:%d\n", time_diff_ms, time_diff_cyc);
-	zassert_true(time_diff_ms >= 3000 && time_diff_ms <= 3010,
+	zassert_true(time_diff_ms >= 3000 && time_diff_ms <= 3020,
 		     "k_uptime_get is not accurated after exiting dlps!");
 	zassert_true(
 		k_cyc_to_ms_floor32(time_diff_cyc) >= 3000 &&
@@ -227,37 +231,74 @@ ZTEST(timeout_wakeup, test_timing_apis)
 		k_cyc_to_ms_floor32(time_diff_cyc));
 }
 
-void test_exclude_timer_handler(void *dummy)
-{
-	test_exclude_timer_cnt = 44;
-}
-
 void test_timer_handler_oneshot(struct k_timer *dummy)
 {
 	k_timer_stop(&test_timer);
 	k_sem_give(&test_thread_sem);
 }
 
-ZTEST(timeout_wakeup, test_exclude_timer)
+#define MAX_RECORDS 3
+int execution_order[MAX_RECORDS];
+int exec_idx;
+
+void test_exclude_timer_handler(void *dummy)
+{
+	test_exclude_timer_cnt = 44;
+	if (exec_idx < MAX_RECORDS) {
+		execution_order[exec_idx++] = 3;
+	}
+}
+
+void pend_cb_before_driver_resume(void)
+{
+	if (exec_idx < MAX_RECORDS) {
+		execution_order[exec_idx++] = 2;
+	}
+}
+
+void restore_tag_cb(void)
+{
+	if (exec_idx < MAX_RECORDS) {
+		execution_order[exec_idx++] = 1;
+	}
+}
+
+void add_delay_to_trigger_exclude_timer(void)
+{
+	DBG_DIRECT("add delay to make systick isr triggered before driver resume!");
+	DBG_DIRECT("add delay to make systick isr triggered before driver resume!");
+}
+
+ZTEST(timeout_wakeup, test_exclude_timer_execute_after_driver_resume)
 {
 	uint32_t wakeup_count_timer;
 	bool status;
-
+	platform_pm_register_callback_func_with_priority((void *)restore_tag_cb,
+							 PLATFORM_PM_RESTORE, -2);
+	platform_pm_register_callback_func_with_priority((void *)pend_cb_before_driver_resume,
+							 PLATFORM_PM_PEND, -2);
+	platform_pm_register_callback_func_with_priority((void *)add_delay_to_trigger_exclude_timer,
+							 PLATFORM_PM_PEND, -3);
 	power_get_statistics(&wakeup_count_before_test, &last_wakeup_clk, &last_sleep_clk);
-	status = os_timer_create(&test_exclude_timer, "exclude_timer", 1, 1000, false,
+	status = os_timer_create(&test_exclude_timer, "exclude_timer", 1, 10, false,
 				 test_exclude_timer_handler);
 	zassert_true(status != false, "error creating one-shot timer!");
 	status = os_register_pm_excluded_handle(&test_exclude_timer, PLATFORM_PM_EXCLUDED_TIMER);
 	zassert_true(status != false, "error register exclude timer!");
-	status = os_timer_start(&test_exclude_timer);
-	zassert_true(status != false, "error start exclude timer!");
 
 	k_sem_init(&test_thread_sem, 0, UINT_MAX);
 	k_timer_init(&test_timer, test_timer_handler_oneshot, NULL);
-	k_timer_start(&test_timer, K_SECONDS(3), K_SECONDS(3));
+	k_timer_start(&test_timer, K_SECONDS(1), K_SECONDS(1));
+	status = os_timer_start(&test_exclude_timer);
+	zassert_true(status != false, "error start exclude timer!");
 	k_sem_take(&test_thread_sem, K_FOREVER);
+
 	zassert_true(test_exclude_timer_cnt == 44,
 		     "exclude timer is not executed, which is wrong!");
+	zassert_true(execution_order[0] == 1 && execution_order[1] == 2 && execution_order[2] == 3,
+		     "exclude timer is executed before the driver resume, which is risky! flow "
+		     "is:%d,%d,%d",
+		     execution_order[0], execution_order[1], execution_order[2]);
 	power_get_statistics(&wakeup_count_after_test, &last_wakeup_clk, &last_sleep_clk);
 	wakeup_count_timer = wakeup_count_after_test - wakeup_count_before_test;
 
@@ -265,6 +306,7 @@ ZTEST(timeout_wakeup, test_exclude_timer)
 		 wakeup_count_timer, last_wakeup_clk, last_sleep_clk);
 
 	status = os_unregister_pm_excluded_handle(&test_exclude_timer, PLATFORM_PM_EXCLUDED_TIMER);
+
 	zassert_true(status != false, "error unregister exclude timer!");
 	zassert_true(wakeup_count_timer == 1, "test_exclude_timer failed, wakeup Count:%d\n",
 		     wakeup_count_timer);

--- a/tests/boards/rtl8752h_evb/pm/timeout_wakeup/testcase.yaml
+++ b/tests/boards/rtl8752h_evb/pm/timeout_wakeup/testcase.yaml
@@ -1,6 +1,7 @@
 tests:
   boards.rtl8752h.pm.timeout_wakeup:
     platform_allow:
-      - rtl8752h_evb
+      - rtl8752h_evb/rtl8752htv
+      - rtl8752h_evb/rtl8752hkf
     tags:
       - pm

--- a/tests/boards/rtl87x2g_evb/pm/timeout_wakeup/src/main.c
+++ b/tests/boards/rtl87x2g_evb/pm/timeout_wakeup/src/main.c
@@ -10,6 +10,8 @@
 #include <pm.h>
 #include <os_pm.h>
 #include <os_timer.h>
+#include <trace.h>
+#include <power_manager_unit_platform.h>
 struct triggered_test_item {
 	int key;
 	struct k_work_poll work;
@@ -43,11 +45,6 @@ void test_timer_handler(struct k_timer *dummy)
 		k_sem_give(&test_thread_sem);
 		k_timer_stop(&test_timer);
 	}
-}
-
-void test_exclude_timer_handler(void *dummy)
-{
-	test_exclude_timer_cnt = 44;
 }
 
 void test_timer_handler_oneshot(struct k_timer *dummy)
@@ -181,33 +178,77 @@ ZTEST(timeout_wakeup, test_timing_apis)
 	zassert_true(wakeup_count_timing_apis == 1, "test_timing_apis failed, wakeup Count: %d\n",
 		     wakeup_count_timing_apis);
 	TC_PRINT("sleep time, ms:%lld, cycle:%d\n", time_diff_ms, time_diff_cyc);
-	zassert_true(time_diff_ms >= 3000 && time_diff_ms <= 3010,
+	zassert_true(time_diff_ms >= 3000 && time_diff_ms <= 3020,
 		     "k_uptime_get is not accurated after exiting dlps!");
 	zassert_true(k_cyc_to_ms_floor32(time_diff_cyc) >= 3000 &&
-			     k_cyc_to_ms_floor32(time_diff_cyc) <= 3010,
+			     k_cyc_to_ms_floor32(time_diff_cyc) <= 3020,
 		     "k_cycle_get_32 is not accurated after exiting dlps!");
 }
 
-ZTEST(timeout_wakeup, test_exclude_timer)
+#define MAX_RECORDS 3
+int execution_order[MAX_RECORDS];
+int exec_idx;
+
+void test_exclude_timer_handler(void *dummy)
+{
+	test_exclude_timer_cnt = 44;
+	if (exec_idx < MAX_RECORDS) {
+		execution_order[exec_idx++] = 3;
+	}
+}
+
+void pend_cb_before_driver_resume(void)
+{
+	if (exec_idx < MAX_RECORDS) {
+		execution_order[exec_idx++] = 2;
+	}
+}
+
+void restore_tag_cb(void)
+{
+	if (exec_idx < MAX_RECORDS) {
+		execution_order[exec_idx++] = 1;
+	}
+}
+
+void add_delay_to_trigger_exclude_timer(void)
+{
+	DBG_DIRECT("add delay to make systick isr triggered before driver resume!");
+	DBG_DIRECT("add delay to make systick isr triggered before driver resume!");
+}
+
+ZTEST(timeout_wakeup, test_exclude_timer_execute_after_driver_resume)
 {
 	uint32_t wakeup_count_timer;
 	bool status;
 
+	platform_pm_register_callback_func_with_priority((void *)restore_tag_cb,
+							 PLATFORM_PM_RESTORE, -2);
+	platform_pm_register_callback_func_with_priority((void *)pend_cb_before_driver_resume,
+							 PLATFORM_PM_PEND, -2);
+	platform_pm_register_callback_func_with_priority((void *)add_delay_to_trigger_exclude_timer,
+							 PLATFORM_PM_PEND, -3);
 	power_get_statistics(&wakeup_count_before_test, &last_wakeup_clk, &last_sleep_clk);
-	status = os_timer_create(&test_exclude_timer, "exclude_timer", 1, 1000, false,
+	status = os_timer_create(&test_exclude_timer, "exclude_timer", 1, 80, false,
 				 test_exclude_timer_handler);
 	zassert_true(status != false, "error creating one-shot timer!");
 	status = os_register_pm_excluded_handle(&test_exclude_timer, PLATFORM_PM_EXCLUDED_TIMER);
 	zassert_true(status != false, "error register exclude timer!");
-	status = os_timer_start(&test_exclude_timer);
-	zassert_true(status != false, "error start exclude timer!");
 
 	k_sem_init(&test_thread_sem, 0, UINT_MAX);
 	k_timer_init(&test_timer, test_timer_handler_oneshot, NULL);
-	k_timer_start(&test_timer, K_SECONDS(3), K_SECONDS(3));
+	k_timer_start(&test_timer, K_SECONDS(1), K_SECONDS(1));
+	status = os_timer_start(&test_exclude_timer);
+	zassert_true(status != false, "error start exclude timer!");
+
 	k_sem_take(&test_thread_sem, K_FOREVER);
+
 	zassert_true(test_exclude_timer_cnt == 44,
 		     "exclude timer is not executed, which is wrong!");
+	zassert_true(execution_order[0] == 1 && execution_order[1] == 2 && execution_order[2] == 3,
+		     "exclude timer is executed before the driver resume, which is risky! flow "
+		     "is:%d,%d,%d",
+		     execution_order[0], execution_order[1], execution_order[2]);
 	power_get_statistics(&wakeup_count_after_test, &last_wakeup_clk, &last_sleep_clk);
 	wakeup_count_timer = wakeup_count_after_test - wakeup_count_before_test;
 
@@ -215,6 +256,7 @@ ZTEST(timeout_wakeup, test_exclude_timer)
 		 wakeup_count_timer, last_wakeup_clk, last_sleep_clk);
 
 	status = os_unregister_pm_excluded_handle(&test_exclude_timer, PLATFORM_PM_EXCLUDED_TIMER);
+
 	zassert_true(status != false, "error unregister exclude timer!");
 	zassert_true(wakeup_count_timer == 1, "test_exclude_timer failed, wakeup Count:%d\n",
 		     wakeup_count_timer);


### PR DESCRIPTION
- Register Zephyr pendcall function to support the RTK PM pend stage.
- Move systick restore to the final pend stage to ensure that after exiting DLPS, driver resume always comes first, followed by the execution of the timeout callback.
- Add a testcase to verify that the exclude timer is executed before driver resume. Without the adjustment of moving systick restore from restore stage to pend stage, this testcase would fail.