### PR TITLE
bee: pm: support rtk pm pend stage

### DIFF
--- a/kernel/timeout.c
+++ b/kernel/timeout.c
@@ -338,23 +338,20 @@ void z_vrfy_sys_clock_tick_set(uint64_t tick)
 }
 #endif
 
+#if CONFIG_SOC_FAMILY_REALTEK_BEE
 /* To support RTK PM */
-static int32_t pended_ticks;
-
+extern void sys_clock_only_add_cycle_count(int32_t ticks);
 struct _timeout *get_first_timeout(void)
 {
-    sys_dnode_t *t = sys_dlist_peek_head(&timeout_list);
-
-    return t == NULL ? NULL : CONTAINER_OF(t, struct _timeout, node);
+	return first();
 }
 
 struct _timeout *get_next_timeout(struct _timeout *t)
 {
-    sys_dnode_t *n = sys_dlist_peek_next(&timeout_list, &t->node);
-
-    return n == NULL ? NULL : CONTAINER_OF(n, struct _timeout, node);
+	return next(t);
 }
 
+static int32_t pended_ticks;
 void sys_clock_announce_only_add_ticks(int32_t ticks)
 {
 	k_spinlock_key_t key = k_spin_lock(&timeout_lock);
@@ -364,28 +361,24 @@ void sys_clock_announce_only_add_ticks(int32_t ticks)
 	k_spin_unlock(&timeout_lock, key);
 }
 
-extern void sys_clock_only_add_cycle_count(int32_t ticks);
+void sys_clock_restore_tick_and_cycle(void)
+{
+	/* restore cycle_count. */
+	sys_clock_only_add_cycle_count(pended_ticks);
+	/* restore cur_ticks. */
+	curr_tick += pended_ticks;
+}
 
 void sys_clock_announce_process_timeout(void)
 {
 	k_spinlock_key_t key = k_spin_lock(&timeout_lock);
 
-	sys_clock_only_add_cycle_count(pended_ticks);
-
 	struct _timeout *t;
 
-	for (t = first();
-	     (t != NULL) && (t->dticks <= pended_ticks);
-	     t = first()) {
+	for (t = first(); (t != NULL) && (t->dticks <= pended_ticks); t = next(t)) {
 		int dt = t->dticks;
 
-		curr_tick += dt;
 		t->dticks = 0;
-		remove_timeout(t);
-
-		k_spin_unlock(&timeout_lock, key);
-		t->fn(t);
-		key = k_spin_lock(&timeout_lock);
 		pended_ticks -= dt;
 	}
 
@@ -393,7 +386,21 @@ void sys_clock_announce_process_timeout(void)
 		t->dticks -= pended_ticks;
 	}
 
-	curr_tick += pended_ticks;
 	pended_ticks = 0;
+
+	/* Separate the handling of pending tick counts and timeout
+	 * callback functions to avoid errors when a timer is started
+	 * during the timer callback.
+	 */
+
+	for (t = first(); (t != NULL) && (t->dticks == 0); t = first()) {
+		remove_timeout(t);
+
+		k_spin_unlock(&timeout_lock, key);
+		t->fn(t);
+		key = k_spin_lock(&timeout_lock);
+	}
+
 	k_spin_unlock(&timeout_lock, key);
 }
+#endif

--- a/soc/arm/realtek_bee/rtl87x2g/Kconfig.defconfig.series
+++ b/soc/arm/realtek_bee/rtl87x2g/Kconfig.defconfig.series
@@ -37,6 +37,20 @@ config IDLE_STACK_SIZE
 config NUM_METAIRQ_PRIORITIES
 	default 1
 
+config RUNTIME_NMI
+	default y
+
+if PM
+config BT
+	default y
+
+config PM_DEVICE
+	default y
+endif
+
+config REALTEK_USING_SDK_LIB
+	default y if PM || PM_DEVICE
+
 rsource "Kconfig.defconfig.rtl87*"
 
 endif # SOC_SERIES_RTL87X2G

--- a/soc/arm/realtek_bee/rtl87x2g/power.c
+++ b/soc/arm/realtek_bee/rtl87x2g/power.c
@@ -1,3 +1,9 @@
+/*
+ * Copyright (c) 2025 Realtek Semiconductor Corp.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 #include <zephyr/kernel.h>
 #include <zephyr/device.h>
 #include <zephyr/pm/pm.h>
@@ -5,6 +11,7 @@
 #include <zephyr/kernel_structs.h>
 #include <zephyr/init.h>
 #include <string.h>
+#include <stdint.h>
 #include <zephyr/drivers/timer/system_timer.h>
 #include <zephyr/pm/device.h>
 #include <zephyr/pm/device_runtime.h>
@@ -19,16 +26,25 @@
 #include <power_manager_unit_platform.h>
 #include <pm.h>
 #include <rtl_pinmux.h>
+#include "os_pm.h"
+#include <trace.h>
 
 #include <zephyr/logging/log.h>
-LOG_MODULE_DECLARE(soc, CONFIG_SOC_LOG_LEVEL);
+LOG_MODULE_REGISTER(rtl87x2g_pm, LOG_LEVEL_INF);
 
-volatile PINMUXStoreReg_Typedef Pinmux_StoreReg;
-extern void Pinmux_DLPSEnter(void *PeriReg, void *StoreBuf);
-extern void Pinmux_DLPSExit(void *PeriReg, void *StoreBuf);
+struct k_work work_timeout_process;
+struct k_work work_device_resume;
+
+TYPE_SECTION_START_EXTERN(const struct device *, pm_device_slots);
+
+/* Number of devices successfully suspended. */
+static size_t num_susp_rtk;
+
 extern void NMI_Handler(void);
 extern void sys_clock_announce_process_timeout(void);
 extern void pad_short_pulse_wake_up(int Status);
+extern void sys_clock_restore_tick_and_cycle(void);
+extern void os_pm_restore_tickcount(void);
 
 volatile uint32_t CPU_StoreReg[6];
 volatile uint8_t CPU_StoreReg_IPR[96];
@@ -58,8 +74,6 @@ static void CPU_DLPS_Enter(void)
 	/* peripheral reg store */
 	Peripheral_StoreReg[0] = SoC_VENDOR->u_008.REG_LOW_PRI_INT_MODE;
 	Peripheral_StoreReg[1] = SoC_VENDOR->u_00C.REG_LOW_PRI_INT_EN;
-
-	return;
 }
 
 void CPU_DLPS_Exit(void)
@@ -80,9 +94,9 @@ void CPU_DLPS_Exit(void)
 	 * But because all interrupts are masked, these interrupts are pending.
 	 */
 	if ((CPU_StoreReg[0] & CPU_StoreReg[3]) || (CPU_StoreReg[1] & CPU_StoreReg[4]) ||
-		(CPU_StoreReg[2] & CPU_StoreReg[5])) {
+	    (CPU_StoreReg[2] & CPU_StoreReg[5])) {
 		LOG_ERR("miss interrupt: pending register: 0x%x, 0x%x, 0x%x", CPU_StoreReg[3],
-					   CPU_StoreReg[4], CPU_StoreReg[5]);
+			CPU_StoreReg[4], CPU_StoreReg[5]);
 	}
 
 	/* Skip System_IRQn, WDG_IRQn, RXI300_IRQn, RXI300_SEC_IRQn,
@@ -97,30 +111,7 @@ void CPU_DLPS_Exit(void)
 	NVIC->ISER[0] = CPU_StoreReg[0];
 	NVIC->ISER[1] = CPU_StoreReg[1];
 	NVIC->ISER[2] = CPU_StoreReg[2];
-
-	return;
 }
-
-void pm_state_set(enum pm_state state, uint8_t substate_id)
-{
-	ARG_UNUSED(state);
-	ARG_UNUSED(substate_id);
-	return;
-}
-
-void pm_state_exit_post_ops(enum pm_state state, uint8_t substate_id)
-{
-	ARG_UNUSED(state);
-	ARG_UNUSED(substate_id);
-	return;
-}
-
-#ifdef CONFIG_PM_DEVICE
-TYPE_SECTION_START_EXTERN(const struct device *, pm_device_slots);
-
-#if !defined(CONFIG_PM_DEVICE_RUNTIME_EXCLUSIVE)
-/* Number of devices successfully suspended. */
-static size_t num_susp_rtk;
 
 static int pm_suspend_devices_rtk(void)
 {
@@ -128,8 +119,6 @@ static int pm_suspend_devices_rtk(void)
 	Pad_ClearAllWakeupINT();
 	System_WakeupDebounceClear(0);
 	CPU_DLPS_Enter();
-
-	Pinmux_DLPSEnter(PINMUX, (void *)&Pinmux_StoreReg);
 
 	const struct device *devs;
 	size_t devc;
@@ -145,9 +134,7 @@ static int pm_suspend_devices_rtk(void)
 		 * devices with runtime PM enabled.
 		 */
 		if (!device_is_ready(dev) || pm_device_is_busy(dev) ||
-			pm_device_state_is_locked(dev) ||
-			pm_device_wakeup_is_enabled(dev) ||
-			pm_device_runtime_is_enabled(dev)) {
+		    pm_device_wakeup_is_enabled(dev) || pm_device_runtime_is_enabled(dev)) {
 			continue;
 		}
 
@@ -156,62 +143,48 @@ static int pm_suspend_devices_rtk(void)
 		if ((ret == -ENOSYS) || (ret == -ENOTSUP) || (ret == -EALREADY)) {
 			continue;
 		} else if (ret < 0) {
-			LOG_ERR("Device %s did not enter %s state (%d)",
-				dev->name,
-				pm_device_state_str(PM_DEVICE_STATE_SUSPENDED),
-				ret);
+			LOG_ERR("Device %s did not enter %s state (%d)", dev->name,
+				pm_device_state_str(PM_DEVICE_STATE_SUSPENDED), ret);
 			return ret;
 		}
 
 		TYPE_SECTION_START(pm_device_slots)[num_susp_rtk] = dev;
 		num_susp_rtk++;
 	}
-
 	return 0;
 }
 
 void pm_resume_devices_rtk(void)
 {
-	Pinmux_DLPSExit(PINMUX, (void *)&Pinmux_StoreReg);
 	for (int i = (num_susp_rtk - 1); i >= 0; i--) {
 		pm_device_action_run(TYPE_SECTION_START(pm_device_slots)[i],
-					PM_DEVICE_ACTION_RESUME);
+				     PM_DEVICE_ACTION_RESUME);
 	}
 
 	CPU_DLPS_Exit();
 
 	num_susp_rtk = 0;
 }
-#endif  /* !CONFIG_PM_DEVICE_RUNTIME_EXCLUSIVE */
-#endif	/* CONFIG_PM_DEVICE */
 
-#define RTK_PM_WORKQ_STACK_SIZE 512
-#define RTK_PM_WORKQ_PRIORITY K_HIGHEST_THREAD_PRIO
-
-K_THREAD_STACK_DEFINE(rtk_pm_workq_stack_area, RTK_PM_WORKQ_STACK_SIZE);
-
-struct k_work_q rtk_pm_workq;
-
-struct k_work work_timeout_process;
-struct k_work work_device_resume;
-
-void timeout_process_handler(struct k_work *item)
+void pm_state_exit_post_ops(enum pm_state state, uint8_t substate_id)
 {
+	ARG_UNUSED(state);
+	ARG_UNUSED(substate_id);
+}
+
+void pm_reusme_systick_and_process_timeout(void)
+{
+	/* Restore systick after driver resume to ensure no systick isr is triggered and exclude
+	 * timer is timeout out and executed. Restore the sys clock of Zephyr. Note: exclude timer
+	 * cb may rely on the driver resume.
+	 */
+	__disable_irq();
+	os_pm_restore_tickcount();
+	sys_clock_restore_tick_and_cycle();
+	__enable_irq();
+
+	/* Subtract the pended tick from the timeout list and manually trigger a timeout process. */
 	sys_clock_announce_process_timeout();
-	return;
-}
-
-void device_resume_handler(struct k_work *item)
-{
-	pm_resume_devices_rtk();
-	return;
-}
-
-void submit_items_to_rtk_pm_workq(void)
-{
-	k_work_submit_to_queue(&rtk_pm_workq, &work_device_resume);
-	k_work_submit_to_queue(&rtk_pm_workq, &work_timeout_process);
-	return;
 }
 
 /* Initialize power system */
@@ -219,33 +192,20 @@ static int rtl87x2g_power_init(void)
 {
 	int ret = 0;
 
+	/* Init essential APIs related to OS for RTK PM. */
+	os_pm_init();
+
 	bt_power_mode_set(BTPOWER_DEEP_SLEEP);
 	power_mode_set(POWER_DLPS_MODE);
-	z_arm_nmi_set_handler(NMI_Handler);
-	k_work_queue_init(&rtk_pm_workq);
-	k_work_queue_start(&rtk_pm_workq, rtk_pm_workq_stack_area,
-				   K_THREAD_STACK_SIZEOF(rtk_pm_workq_stack_area),
-				   RTK_PM_WORKQ_PRIORITY, NULL);
-	k_work_init(&work_timeout_process, timeout_process_handler);
-	k_work_init(&work_device_resume, device_resume_handler);
-	platform_pm_register_callback_func_with_priority((void *)pm_suspend_devices_rtk,
-		PLATFORM_PM_STORE, 1);
-	/* do timeout function process and devices & nvic resume in
-	 * rtk_pm_workq thread via zephyr's workq mechanism.
-	 */
-	platform_pm_register_callback_func_with_priority((void *)submit_items_to_rtk_pm_workq,
-		PLATFORM_PM_RESTORE, 1);
 
-	/* The rtl87x2g Zephyr has not registered platform_pm_system.schedule_bottom_half_callback
-	 * in rtk power manager. Therefore,
-	 * we need to fine-tune platform_pm_system.stage_time[PLATFORM_PM_PEND]. The default value
-	 * is 100 (equivalent to 3.125ms), which is too large,
-	 * causing the system to wake up too early and thereby increasing power consumption.
-	 * In the Zephyr environment, change this default value to 20.
-	 * If the app has additional registered pend functions, consider increasing this value
-	 * accordingly to ensure the system does not oversleep.
-	 */
-	platform_pm_system.stage_time[PLATFORM_PM_PEND] = 20;
+	z_arm_nmi_set_handler(NMI_Handler);
+
+	platform_pm_register_callback_func_with_priority((void *)pm_suspend_devices_rtk,
+							 PLATFORM_PM_STORE, 1);
+	platform_pm_register_callback_func_with_priority((void *)pm_resume_devices_rtk,
+							 PLATFORM_PM_PEND, -1);
+	platform_pm_register_callback_func_with_priority(
+		(void *)pm_reusme_systick_and_process_timeout, PLATFORM_PM_PEND, INT8_MAX);
 
 	return ret;
 }

--- a/soc/arm/realtek_bee/rtl87x2g/soc.c
+++ b/soc/arm/realtek_bee/rtl87x2g/soc.c
@@ -92,8 +92,6 @@ static int rtk_platform_init(void)
 
 	os_init();
 
-	os_pm_init();
-
 	secure_os_func_ptr_init();
 	RamVectorTableUpdate(SVC_VECTORn, (IRQ_Fun)z_arm_svc);
 

--- a/tests/boards/rtl8762gn_evb/pm/timeout_wakeup/prj.conf
+++ b/tests/boards/rtl8762gn_evb/pm/timeout_wakeup/prj.conf
@@ -1,8 +1,4 @@
 CONFIG_PM=y
-CONFIG_PM_DEVICE=y
-CONFIG_PM_POLICY_CUSTOM=n # use zephyr pm flow, enable this config; use realtek pm flow, disable this config.
-CONFIG_RUNTIME_NMI=y # customize NMI for Power Manager
-CONFIG_REALTEK_USING_SDK_LIB=y
 
 CONFIG_POLL=y
 

--- a/tests/boards/rtl8762gn_evb/pm/timeout_wakeup/src/main.c
+++ b/tests/boards/rtl8762gn_evb/pm/timeout_wakeup/src/main.c
@@ -153,7 +153,7 @@ ZTEST(timeout_wakeup, test_triggered_work_wakeup)
 	time_diff = tag2-tag1;
 	LOG_INF("after dlps!");/*check log time stamp*/
 	zassert_true(time_diff >= TRIGGERED_WORK_NUMBERS*100 && time_diff <=
-			TRIGGERED_WORK_NUMBERS * 100 + 1000,
+			TRIGGERED_WORK_NUMBERS * 100 + 1020,
 			"k_uptime_get is not accurate after dlps! time diff (ms) is %lld",
 			time_diff);
 	power_get_statistics(&wakeup_count_after_test, &last_wakeup_clk, &last_sleep_clk);


### PR DESCRIPTION
- Register Zephyr pendcall function to support the RTK PM pend stage.
- Move systick restore to the final pend stage to ensure that after exiting DLPS, driver resume always comes first, followed by the execution of the timeout callback.
- Add a testcase to verify that the exclude timer is executed before driver resume. Without the adjustment of moving systick restore from restore stage to pend stage, this testcase would fail.