### PR TITLE
tests: btmac_wakeup: check if btmac has overslept

### DIFF
--- a/tests/boards/rtl8752h_evb/pm/btmac_wakeup/src/main.c
+++ b/tests/boards/rtl8752h_evb/pm/btmac_wakeup/src/main.c
@@ -16,9 +16,7 @@
 #include <pm.h>
 #endif
 
-#include "trace.h"
-
-#define LE_ADV_DURATION_SECONDS 20
+#define LE_ADV_DURATION_SECONDS 120
 #define DEVICE_NAME             CONFIG_BT_DEVICE_NAME
 #define DEVICE_NAME_LEN         (sizeof(DEVICE_NAME) - 1)
 
@@ -29,6 +27,9 @@ static uint32_t last_wakeup_clk, last_sleep_clk;
 static const struct bt_data ad[] = {
 	BT_DATA_BYTES(BT_DATA_FLAGS, BT_LE_AD_NO_BREDR),
 };
+
+uint32_t last_total_wakeup_time, updated_total_wakeup_time;
+uint32_t unexpected_time;
 
 /* Set Scan Response data */
 static const struct bt_data sd[] = {
@@ -49,12 +50,9 @@ ZTEST(btmac_wakeup, test_adv_wakeup)
 	/* Start advertising */
 
 	err = bt_le_adv_start(
-		BT_LE_ADV_PARAM(0, BT_GAP_ADV_FAST_INT_MIN_2, BT_GAP_ADV_FAST_INT_MAX_2, NULL), ad,
+		BT_LE_ADV_PARAM(0, BT_GAP_ADV_SLOW_INT_MIN, BT_GAP_ADV_SLOW_INT_MAX, NULL), ad,
 		ARRAY_SIZE(ad), sd, ARRAY_SIZE(sd));
-	/*
-	 *err = bt_le_adv_start(BT_LE_ADV_NCONN, ad, ARRAY_SIZE(ad),
-	 *		      sd, ARRAY_SIZE(sd));
-	 */
+
 	zassert_equal(err, 0, "Advertising failed to start (err %d)\n", err);
 
 	printk("Advertising started\n");
@@ -64,12 +62,27 @@ ZTEST(btmac_wakeup, test_adv_wakeup)
 	power_get_statistics(&wakeup_count_after_test, &last_wakeup_clk, &last_sleep_clk);
 	uint32_t wakeup_count_btmac = wakeup_count_after_test - wakeup_count_before_test;
 
-	TC_PRINT("wakeupCount: %d, last_wakeup_clk:%d, last_sleep_clk:%d\n", wakeup_count_btmac,
-		 last_wakeup_clk, last_sleep_clk);
-	zassert_true(wakeup_count_btmac <= LE_ADV_DURATION_SECONDS * 1000 / 100 &&
-			     wakeup_count_btmac >= LE_ADV_DURATION_SECONDS * 1000 /
-							   (150 + 10), /* 0~10ms random delay */
-		     "failed, wakeup Count: %d\n", wakeup_count_btmac);
+	zassert_true(wakeup_count_btmac == LE_ADV_DURATION_SECONDS && unexpected_time == 0,
+	"wakeup count: %d, BTMAC wakeup late count: %d\n", wakeup_count_btmac, unexpected_time);
+}
+
+void record_in_enter_stage(void)
+{
+	last_total_wakeup_time = platform_pm_system.total_wakeup_time;
+}
+
+void record_in_pend_stage(void)
+{
+	updated_total_wakeup_time = platform_pm_system.total_wakeup_time;
+	
+	/* Calculate the duration time of the last wakeup (unit: microseconds)
+     * If over 1 second (1000000 us), treat as anomaly.
+	 */
+	if (updated_total_wakeup_time - last_total_wakeup_time >= 1000000)
+	{
+		unexpected_time++;
+		TC_PRINT("Unexpected case: BTMAC might wake up late!\n");
+	}
 }
 
 void teardown_fn(void *data)
@@ -77,4 +90,12 @@ void teardown_fn(void *data)
 	lps_mode_pause();
 }
 
-ZTEST_SUITE(btmac_wakeup, NULL, NULL, NULL, NULL, teardown_fn);
+void register_pm_cb(void *data)
+{
+	platform_pm_register_callback_func((void *)record_in_enter_stage,
+							 PLATFORM_PM_STORE);
+	platform_pm_register_callback_func((void *)record_in_pend_stage,
+							 PLATFORM_PM_PEND);
+}
+
+ZTEST_SUITE(btmac_wakeup, NULL, NULL, register_pm_cb, NULL, teardown_fn);


### PR DESCRIPTION
1. adjust adv interrupt to 1s.
2. calculte the wakeup duration time to judge if the btmac has missed a adv event.