### PR TITLE
tests: rtl87x2g: pad_wakup: support model-A evb

### DIFF
--- a/tests/boards/rtl87x2g_evb/pm/pad_wakeup_dlps/boards/rtl87x2g_evb.overlay
+++ b/tests/boards/rtl87x2g_evb/pm/pad_wakeup_dlps/boards/rtl87x2g_evb.overlay
@@ -1,22 +1,9 @@
 / {
-	// leds {
-	// 	compatible = "gpio-leds";
-	// 	led0: led_0 {
-	// 		gpios = <&gpioa 1 GPIO_ACTIVE_HIGH>;
-	// 		label = "Green LED 0";
-	// 	};
-	// 	led1: led_1 {
-	// 		gpios = <&gpioa 2 GPIO_ACTIVE_HIGH>;
-	// 		label = "Green LED 1";
-	// 	};
-	// };
-
     buttons {
 		compatible = "gpio-keys";
 		button2: button_2 {
-			// gpios = <&gpioa 25 GPIO_ACTIVE_HIGH>;
-			gpios = <&gpiob 5 GPIO_ACTIVE_HIGH>;
-			label = "Push button switch 2";
+			gpios = <&gpioa 6 GPIO_ACTIVE_HIGH>;
+			label = "Key4 on RTL87X2G EVB Model A";
 		};
 	};
 };

--- a/tests/boards/rtl87x2g_evb/pm/pad_wakeup_dlps/src/main.c
+++ b/tests/boards/rtl87x2g_evb/pm/pad_wakeup_dlps/src/main.c
@@ -5,7 +5,7 @@
  */
 #include <zephyr/kernel.h>
 #include <zephyr/drivers/gpio.h>
-#include <zephyr/dt-bindings/gpio/realtek-rtl87x2g-gpio.h>
+#include <zephyr/dt-bindings/gpio/realtek-bee-gpio.h>
 #include <zephyr/ztest.h>
 #include <pm.h>
 
@@ -40,7 +40,7 @@ static void button_cb(const struct device *port, struct gpio_callback *cb, gpio_
 static void button_pressed(struct k_work *work)
 {
 	key_press_num++;
-	printk("KEY0 button press tested, key_press_num:%d!\n", key_press_num);
+	printk("KEY4 button press tested, key_press_num:%d!\n", key_press_num);
 	if (key_press_num == KEY_PRESS_NUMBERS) {
 		k_sem_give(&test_thread_sem);
 	}
@@ -55,7 +55,7 @@ ZTEST(pad_wakeup_dlps, test_gpio_wakeup_dlps)
 
 	err = gpio_pin_configure(button_dev, BUTTON_PIN,
 				 BUTTON_FLAGS | GPIO_INPUT | GPIO_PULL_UP |
-					 RTL87X2G_GPIO_INPUT_PM_WAKEUP);
+					 BEE_GPIO_INPUT_PM_WAKEUP);
 	if (err) {
 		TC_PRINT("gpio_pin_configure err!");
 	}
@@ -73,7 +73,7 @@ ZTEST(pad_wakeup_dlps, test_gpio_wakeup_dlps)
 	printk("WARNING: Buttons not supported on this board.\n");
 #endif
 	power_get_statistics(&wakeup_count_before_test, &last_wakeup_clk, &last_sleep_clk);
-	printk("Please press Key0 %d times!!\n", KEY_PRESS_NUMBERS);
+	printk("Please press KEY4 %d times!!\n", KEY_PRESS_NUMBERS);
 	k_sem_init(&test_thread_sem, 0, UINT_MAX);
 	k_sem_take(&test_thread_sem, K_FOREVER);
 	power_get_statistics(&wakeup_count_after_test, &last_wakeup_clk, &last_sleep_clk);

--- a/tests/boards/rtl87x2g_evb/pm/pad_wakeup_powerdown/boards/rtl87x2g_evb.overlay
+++ b/tests/boards/rtl87x2g_evb/pm/pad_wakeup_powerdown/boards/rtl87x2g_evb.overlay
@@ -1,22 +1,9 @@
 / {
-	// leds {
-	// 	compatible = "gpio-leds";
-	// 	led0: led_0 {
-	// 		gpios = <&gpioa 1 GPIO_ACTIVE_HIGH>;
-	// 		label = "Green LED 0";
-	// 	};
-	// 	led1: led_1 {
-	// 		gpios = <&gpioa 2 GPIO_ACTIVE_HIGH>;
-	// 		label = "Green LED 1";
-	// 	};
-	// };
-
     buttons {
 		compatible = "gpio-keys";
 		button2: button_2 {
-			// gpios = <&gpioa 25 GPIO_ACTIVE_HIGH>;
-			gpios = <&gpiob 5 GPIO_ACTIVE_HIGH>;
-			label = "Push button switch 2";
+			gpios = <&gpioa 6 GPIO_ACTIVE_HIGH>;
+			label = "Key4 on RTL87X2G EVB Model A";
 		};
 	};
 };

--- a/tests/boards/rtl87x2g_evb/pm/pad_wakeup_powerdown/src/main.c
+++ b/tests/boards/rtl87x2g_evb/pm/pad_wakeup_powerdown/src/main.c
@@ -5,7 +5,7 @@
  */
 #include <zephyr/kernel.h>
 #include <zephyr/drivers/gpio.h>
-#include <zephyr/dt-bindings/gpio/realtek-rtl87x2g-gpio.h>
+#include <zephyr/dt-bindings/gpio/realtek-bee-gpio.h>
 #include <zephyr/ztest.h>
 #include <pm.h>
 
@@ -36,7 +36,7 @@ static void button_cb(const struct device *port, struct gpio_callback *cb, gpio_
 static void button_pressed(struct k_work *work)
 {
 	key_press_num++;
-	printk("button press tested, key_press_num:%d!\n", key_press_num);
+	printk("KEY4 button press tested, key_press_num:%d!\n", key_press_num);
 	if (key_press_num == KEY_PRESS_NUMBERS) {
 		k_sem_give(&test_thread_sem);
 	}
@@ -63,7 +63,7 @@ ZTEST(pad_wakeup_powerdown, test_gpio_wakeup_powerdown)
 
 	err = gpio_pin_configure(button_dev, BUTTON_PIN,
 				 BUTTON_FLAGS | GPIO_INPUT | GPIO_PULL_UP |
-					 RTL87X2G_GPIO_INPUT_PM_WAKEUP);
+					 BEE_GPIO_INPUT_PM_WAKEUP);
 	if (err) {
 		TC_PRINT("gpio_pin_configure err!");
 	}


### PR DESCRIPTION
1. use key4 on model A evb to test pad wakeup