### PR TITLE
drivers: bee: store immediately after register ops

### DIFF
--- a/drivers/adc/adc_bee.c
+++ b/drivers/adc/adc_bee.c
@@ -21,8 +21,16 @@
 #if defined(CONFIG_SOC_SERIES_RTL87X2G)
 #include <rtl_adc.h>
 #include <adc_lib.h>
+
+#define BEE_ADC_SCHED_CTRL ADC_SCHED_CTRL
+#define BEE_ADC_CTRL_INT   ADC_CTRL_INT
+#define BEE_ADC_DIG_CTRL   ADC_DIG_CTRL
 #elif defined(CONFIG_SOC_SERIES_RTL8752H)
 #include <rtl876x_adc.h>
+
+#define BEE_ADC_SCHED_CTRL SCHCR
+#define BEE_ADC_CTRL_INT   INTCR
+#define BEE_ADC_DIG_CTRL   CR
 #endif
 
 #define ADC_CONTEXT_USES_KERNEL_TIMER
@@ -32,8 +40,8 @@
 LOG_MODULE_REGISTER(adc_bee, CONFIG_ADC_LOG_LEVEL);
 
 #ifdef CONFIG_PM_DEVICE
-	extern void ADC_DLPSEnter(void *PeriReg, void *StoreBuf);
-	extern void ADC_DLPSExit(void *PeriReg, void *StoreBuf);
+extern void ADC_DLPSEnter(void *PeriReg, void *StoreBuf);
+extern void ADC_DLPSExit(void *PeriReg, void *StoreBuf);
 #endif
 
 struct adc_bee_config {
@@ -89,6 +97,10 @@ static int adc_bee_start_read(const struct device *dev, const struct adc_sequenc
 
 	ADC_BitMapConfig(adc, BIT(cfg->channels) - 1, DISABLE);
 	ADC_BitMapConfig(adc, sequence->channels, ENABLE);
+
+#ifdef CONFIG_PM_DEVICE
+	data->store_buf.adc_reg[1] = adc->BEE_ADC_SCHED_CTRL;
+#endif
 
 	data->buffer = sequence->buffer;
 	adc_context_start_read(&data->ctx, sequence);
@@ -166,6 +178,11 @@ static void adc_context_start_sampling(struct adc_context *ctx)
 
 	ADC_INTConfig(adc, ADC_INT_ONE_SHOT_DONE, ENABLE);
 	ADC_Cmd(adc, ADC_ONE_SHOT_MODE, ENABLE);
+
+#ifdef CONFIG_PM_DEVICE
+	data->store_buf.adc_reg[2] = adc->BEE_ADC_CTRL_INT;
+	data->store_buf.adc_reg[0] = adc->BEE_ADC_DIG_CTRL;
+#endif
 }
 
 static void adc_context_update_buffer_pointer(struct adc_context *ctx, bool repeat_sampling)
@@ -204,6 +221,10 @@ static void adc_bee_isr(const struct device *dev)
 		ADC_Cmd(adc, ADC_ONE_SHOT_MODE, DISABLE);
 		ADC_INTConfig(adc, ADC_INT_ONE_SHOT_DONE, DISABLE);
 		ADC_ClearINTPendingBit(adc, ADC_INT_ONE_SHOT_DONE);
+#ifdef CONFIG_PM_DEVICE
+		data->store_buf.adc_reg[2] = adc->BEE_ADC_CTRL_INT;
+		data->store_buf.adc_reg[0] = adc->BEE_ADC_DIG_CTRL;
+#endif
 		adc_context_on_sampling_done(&data->ctx, dev);
 	}
 }
@@ -218,9 +239,6 @@ static int adc_bee_pm_action(const struct device *dev, enum pm_device_action act
 
 	switch (action) {
 	case PM_DEVICE_ACTION_SUSPEND:
-
-		ADC_DLPSEnter(adc, &data->store_buf);
-
 		/* Move pins to sleep state */
 		err = pinctrl_apply_state(cfg->pcfg, PINCTRL_STATE_SLEEP);
 		if ((err < 0) && (err != -ENOENT)) {
@@ -257,6 +275,7 @@ static int adc_bee_init(const struct device *dev)
 {
 	struct adc_bee_data *data = dev->data;
 	const struct adc_bee_config *cfg = dev->config;
+	ADC_TypeDef *adc = (ADC_TypeDef *)cfg->reg;
 	int ret;
 
 	data->dev = dev;
@@ -286,7 +305,11 @@ static int adc_bee_init(const struct device *dev)
 
 	adc_init_struct.ADC_SchIndex[cfg->channels - 1] = INTERNAL_VBAT_MODE;
 
-	ADC_Init(ADC, &adc_init_struct);
+	ADC_Init(adc, &adc_init_struct);
+
+#ifdef CONFIG_PM_DEVICE
+	ADC_DLPSEnter(adc, &data->store_buf);
+#endif
 
 	cfg->irq_config_func(dev);
 

--- a/drivers/counter/counter_bee_rtc.c
+++ b/drivers/counter/counter_bee_rtc.c
@@ -247,7 +247,6 @@ static int counter_bee_rtc_init(const struct device *dev)
 	const struct counter_bee_rtc_config *cfg = dev->config;
 	struct counter_bee_rtc_data *data = dev->data;
 
-	/* use clock_control_get_rate if clock driver is available */
 	data->freq = cfg->src_clk_freq / cfg->prescaler;
 
 	cfg->irq_config(dev);

--- a/drivers/counter/counter_bee_timer.c
+++ b/drivers/counter/counter_bee_timer.c
@@ -184,8 +184,8 @@ static int counter_bee_timer_set_top_value(const struct device *dev,
 	int err = 0;
 
 	for (uint32_t i = 0; i < cfg->counter_info.channels; i++) {
-		/* Overflow can be changed only when all alarms are
-		 * disables.
+		/* Top value can be changed only when all channels are
+		 * disabled.
 		 */
 		if (data->alarm[i].callback) {
 			return -EBUSY;
@@ -373,7 +373,6 @@ static int counter_bee_timer_init(const struct device *dev)
 	void *timer_base = (void *)cfg->reg;
 	uint8_t clock_div;
 
-	/* use clock_control_get_rate if clock driver is available */
 	uint32_t pclk = 40000000;
 
 	(void)clock_control_on(BEE_CLOCK_CONTROLLER, (clock_control_subsys_t)&cfg->clkid);

--- a/drivers/counter/counter_bee_timer.c
+++ b/drivers/counter/counter_bee_timer.c
@@ -44,10 +44,10 @@
 LOG_MODULE_REGISTER(counter_bee_timer, CONFIG_COUNTER_LOG_LEVEL);
 
 #ifdef CONFIG_PM_DEVICE
-	extern void ENHTIM_DLPSEnter(void *PeriReg, void *StoreBuf);
-	extern void ENHTIM_DLPSExit(void *PeriReg, void *StoreBuf);
-	extern void TIM_DLPSEnter(void *PeriReg, void *StoreBuf);
-	extern void TIM_DLPSExit(void *PeriReg, void *StoreBuf);
+extern void ENHTIM_DLPSEnter(void *PeriReg, void *StoreBuf);
+extern void ENHTIM_DLPSExit(void *PeriReg, void *StoreBuf);
+extern void TIM_DLPSEnter(void *PeriReg, void *StoreBuf);
+extern void TIM_DLPSExit(void *PeriReg, void *StoreBuf);
 #endif
 
 struct counter_bee_ch_data {
@@ -315,13 +315,6 @@ static int counter_bee_timer_pm_action(const struct device *dev, enum pm_device_
 
 	switch (action) {
 	case PM_DEVICE_ACTION_SUSPEND:
-
-		if (cfg->enhanced) {
-			ENHTIM_DLPSEnter(timer_base, &data->store_buf);
-		} else {
-			TIM_DLPSEnter(timer_base, &data->store_buf);
-		}
-
 		break;
 	case PM_DEVICE_ACTION_RESUME:
 		if (cfg->enhanced) {
@@ -457,6 +450,9 @@ static int counter_bee_timer_init(const struct device *dev)
 		ENHTIM_Init((ENHTIM_TypeDef *)timer_base, &enh_tim_init_struct);
 		LOG_DBG("enhed %s, ctrl=%x, line%d\n", dev->name,
 			((ENHTIM_TypeDef *)timer_base)->BEE_ENH_TIM_REG_CR, __LINE__);
+#ifdef CONFIG_PM_DEVICE
+		ENHTIM_DLPSEnter(timer_base, &data->store_buf);
+#endif
 	} else {
 		TIM_TimeBaseInitTypeDef timer_init_struct;
 		TIM_StructInit(&timer_init_struct);
@@ -470,6 +466,9 @@ static int counter_bee_timer_init(const struct device *dev)
 		TIM_TimeBaseInit((TIM_TypeDef *)timer_base, &timer_init_struct);
 		LOG_DBG("not enhed %s, ctrl=%x, line%d\n", dev->name,
 			((TIM_TypeDef *)timer_base)->BEE_TIM_REG_CONTROLREG, __LINE__);
+#ifdef CONFIG_PM_DEVICE
+		TIM_DLPSEnter(timer_base, &data->store_buf);
+#endif
 	}
 
 	return 0;

--- a/drivers/dma/dma_bee.c
+++ b/drivers/dma/dma_bee.c
@@ -82,10 +82,6 @@ struct dma_bee_data {
 
 extern FlagStatus GDMA_GetSuspendChannelStatus(GDMA_ChannelTypeDef *GDMA_Channelx);
 
-/*
- * API functions
- */
-
 static int dma_bee_configure(const struct device *dev, uint32_t channel, struct dma_config *dma_cfg)
 {
 	const struct dma_bee_config *cfg = dev->config;

--- a/drivers/gpio/gpio_bee.c
+++ b/drivers/gpio/gpio_bee.c
@@ -50,7 +50,7 @@
 #define BEE_System_WakeUpPinEnable(pin, pol, deb_en) System_WakeUpPinEnable(pin, pol, deb_en)
 #define BEE_GPIO_REG_INTSATUS                        GPIO_INT_STS
 #define BEE_GPIO_REG_INT_EN                          GPIO_INT_EN
-
+#define BEE_GPIO_REG_DR                              GPIO_DR
 extern uint32_t GPIO_SwapDebPinBit(GPIO_TypeDef *GPIOx, uint32_t GPIO_Pin);
 #elif defined(CONFIG_SOC_SERIES_RTL8752H)
 #define BEE_GPIO_WriteBit(port, bit, val)            GPIO_WriteBit(bit, val)
@@ -68,13 +68,14 @@ extern uint32_t GPIO_SwapDebPinBit(GPIO_TypeDef *GPIOx, uint32_t GPIO_Pin);
 #define BEE_System_WakeUpPinEnable(pin, pol, deb_en) System_WakeUpPinEnable(pin, pol, deb_en, 0)
 #define BEE_GPIO_REG_INTSATUS                        INTSTATUS
 #define BEE_GPIO_REG_INT_EN                          INTEN
+#define BEE_GPIO_REG_DR                              DATAOUT
 #endif
 
 LOG_MODULE_REGISTER(gpio_bee, CONFIG_GPIO_LOG_LEVEL);
 
 #ifdef CONFIG_PM_DEVICE
-	extern void GPIO_DLPSEnter(void *PeriReg, void *StoreBuf);
-	extern void GPIO_DLPSExit(void *PeriReg, void *StoreBuf);
+extern void GPIO_DLPSEnter(void *PeriReg, void *StoreBuf);
+extern void GPIO_DLPSExit(void *PeriReg, void *StoreBuf);
 #endif
 
 static int gpio_bee_gpio2pad(uint8_t port_num, uint32_t pin)
@@ -295,6 +296,10 @@ static int gpio_bee_pin_configure(const struct device *port, gpio_pin_t pin, gpi
 	}
 
 #ifdef CONFIG_PM_DEVICE
+	GPIO_DLPSEnter(port_base, &data->store_buf);
+#endif
+
+#ifdef CONFIG_PM_DEVICE
 	sys_snode_t *prev;
 
 	if (flags & GPIO_OUTPUT) {
@@ -340,8 +345,10 @@ static int gpio_bee_port_set_masked_raw(const struct device *port, gpio_port_pin
 					gpio_port_value_t value)
 {
 	const struct gpio_bee_config *config = port->config;
+	struct gpio_bee_data *data;
 	GPIO_TypeDef *port_base;
 
+	data = port->data;
 	port_base = config->port_base;
 
 	gpio_port_pins_t pins_value = BEE_GPIO_ReadInputData(port_base);
@@ -349,17 +356,27 @@ static int gpio_bee_port_set_masked_raw(const struct device *port, gpio_port_pin
 	pins_value = (pins_value & ~mask) | (mask & value);
 	BEE_GPIO_Write(port_base, pins_value);
 
+#ifdef CONFIG_PM_DEVICE
+	data->store_buf.gpio_reg[0] = port_base->BEE_GPIO_REG_DR;
+#endif
+
 	return 0;
 }
 
 static int gpio_bee_port_set_bits_raw(const struct device *port, gpio_port_pins_t pins)
 {
 	const struct gpio_bee_config *config = port->config;
+	struct gpio_bee_data *data;
 	GPIO_TypeDef *port_base;
 
+	data = port->data;
 	port_base = config->port_base;
 
 	BEE_GPIO_SetBits(port_base, pins);
+
+#ifdef CONFIG_PM_DEVICE
+	data->store_buf.gpio_reg[0] = port_base->BEE_GPIO_REG_DR;
+#endif
 
 	return 0;
 }
@@ -367,11 +384,17 @@ static int gpio_bee_port_set_bits_raw(const struct device *port, gpio_port_pins_
 static int gpio_bee_port_clear_bits_raw(const struct device *port, gpio_port_pins_t pins)
 {
 	const struct gpio_bee_config *config = port->config;
+	struct gpio_bee_data *data;
 	GPIO_TypeDef *port_base;
 
+	data = port->data;
 	port_base = config->port_base;
 
 	BEE_GPIO_ResetBits(port_base, pins);
+
+#ifdef CONFIG_PM_DEVICE
+	data->store_buf.gpio_reg[0] = port_base->BEE_GPIO_REG_DR;
+#endif
 
 	return 0;
 }
@@ -379,8 +402,10 @@ static int gpio_bee_port_clear_bits_raw(const struct device *port, gpio_port_pin
 static int gpio_bee_port_toggle_bits(const struct device *port, gpio_port_pins_t pins)
 {
 	const struct gpio_bee_config *config = port->config;
+	struct gpio_bee_data *data;
 	GPIO_TypeDef *port_base;
 
+	data = port->data;
 	port_base = config->port_base;
 
 	uint32_t pins_value = BEE_GPIO_ReadInputData(port_base);
@@ -389,6 +414,10 @@ static int gpio_bee_port_toggle_bits(const struct device *port, gpio_port_pins_t
 	BEE_GPIO_Write(port_base, pins_value);
 	LOG_DBG("port=%s, pin=0x%x, pins_value=0x%x, line%d\n", port->name, pins, pins_value,
 		__LINE__);
+
+#ifdef CONFIG_PM_DEVICE
+	data->store_buf.gpio_reg[0] = port_base->BEE_GPIO_REG_DR;
+#endif
 
 	return 0;
 }
@@ -487,6 +516,10 @@ static int gpio_bee_pin_interrupt_configure(const struct device *port, gpio_pin_
 	BEE_GPIO_ClearINTPendingBit(port_base, gpio_bit);
 	BEE_GPIO_MaskINTConfig(port_base, gpio_bit, DISABLE);
 
+#ifdef CONFIG_PM_DEVICE
+	GPIO_DLPSEnter(port_base, &data->store_buf);
+#endif
+
 	return 0;
 }
 
@@ -580,8 +613,8 @@ static void wakeup_pad_pm_suspend(const struct device *port, struct pm_pad_node 
 			bool high_trigger = port_base->GPIO_EXT_DEB_POL_CTL & GPIO_Pin_Swap;
 			bool edge_trigger = port_base->GPIO_INT_LV & BIT(gpio_num);
 #elif defined(CONFIG_SOC_SERIES_RTL8752H)
-			bool high_trigger = port_base->INTPOLARITY & BIT(gpio_num);
-			bool edge_trigger = port_base->INTTYPE & BIT(gpio_num);
+		bool high_trigger = port_base->INTPOLARITY & BIT(gpio_num);
+		bool edge_trigger = port_base->INTTYPE & BIT(gpio_num);
 #endif
 
 			if (edge_trigger) {
@@ -703,8 +736,6 @@ static int gpio_bee_pm_action(const struct device *port, enum pm_device_action a
 				break;
 			}
 		}
-
-		GPIO_DLPSEnter(port_base, &data->store_buf);
 
 		break;
 	case PM_DEVICE_ACTION_RESUME:

--- a/drivers/gpio/gpio_bee.c
+++ b/drivers/gpio/gpio_bee.c
@@ -221,8 +221,7 @@ static int gpio_bee_pin_configure(const struct device *port, gpio_pin_t pin, gpi
 		Pad_Config(pad_pin, PAD_SW_MODE, PAD_NOT_PWRON, PAD_PULL_NONE, PAD_OUT_DISABLE,
 			   PAD_OUT_HIGH);
 	} else {
-		/* config pad pull status */
-
+		/* configure pad pull status */
 		if (flags & GPIO_PULL_UP) {
 			pull_config = PAD_PULL_UP;
 		} else if (flags & GPIO_PULL_DOWN) {
@@ -231,8 +230,7 @@ static int gpio_bee_pin_configure(const struct device *port, gpio_pin_t pin, gpi
 			pull_config = PAD_PULL_NONE;
 		}
 
-		/* config gpio */
-
+		/* configure gpio */
 		GPIO_StructInit(&gpio_init_struct);
 
 		if (debounce_ms) {
@@ -786,16 +784,6 @@ static void gpio_bee_isr(void *arg)
 	}
 }
 
-/**
- * @brief Initialize GPIO port
- *
- * Perform basic initialization of a GPIO port. The code
- * will enable the clock for corresponding peripheral.
- *
- * @param dev GPIO device struct
- *
- * @return 0
- */
 static int gpio_bee_init(const struct device *dev)
 {
 	struct gpio_bee_data *data = dev->data;

--- a/drivers/gpio/gpio_bee.h
+++ b/drivers/gpio/gpio_bee.h
@@ -7,10 +7,6 @@
 #ifndef ZEPHYR_DRIVERS_GPIO_GPIO_BEE_H_
 #define ZEPHYR_DRIVERS_GPIO_GPIO_BEE_H_
 
-/**
- * @file header for BEE GPIO
- */
-
 #include <zephyr/drivers/clock_control.h>
 #include <zephyr/drivers/reset.h>
 #include <zephyr/drivers/gpio.h>
@@ -24,8 +20,6 @@
 #include <zephyr/sys/slist.h>
 #endif
 
-/* GPIO buses definitions */
-
 struct gpio_bee_irq_info {
 	const struct device *irq_dev;
 	uint8_t num_irq;
@@ -35,9 +29,6 @@ struct gpio_bee_irq_info {
 	} gpio_irqs[];
 };
 
-/**
- * @brief configuration of GPIO device
- */
 struct gpio_bee_config {
 	struct gpio_driver_config common;
 	uint16_t clkid;
@@ -68,9 +59,6 @@ struct pm_pad_node_list {
 
 #endif
 
-/**
- * @brief driver data
- */
 struct gpio_bee_data {
 	struct gpio_driver_data common;
 	const struct device *dev;

--- a/drivers/i2c/i2c_bee.c
+++ b/drivers/i2c/i2c_bee.c
@@ -382,6 +382,7 @@ static int i2c_bee_configure(const struct device *dev, uint32_t dev_config)
 
 	I2C_Init(i2c, &i2c_init_struct);
 
+	/* Enable i2c device */
 	I2C_Cmd(i2c, ENABLE);
 error:
 	k_sem_give(&data->bus_mutex);

--- a/drivers/i2c/i2c_bee.c
+++ b/drivers/i2c/i2c_bee.c
@@ -33,8 +33,8 @@ LOG_MODULE_REGISTER(i2c_bee, CONFIG_I2C_LOG_LEVEL);
 #endif
 
 #ifdef CONFIG_PM_DEVICE
-	extern void I2C_DLPSEnter(void *PeriReg, void *StoreBuf);
-	extern void I2C_DLPSExit(void *PeriReg, void *StoreBuf);
+extern void I2C_DLPSEnter(void *PeriReg, void *StoreBuf);
+extern void I2C_DLPSExit(void *PeriReg, void *StoreBuf);
 #endif
 
 #define I2C_TIMEOUT 0xFFFFF
@@ -111,6 +111,10 @@ static void i2c_bee_isr(const struct device *dev)
 		I2C_ClearINTPendingBit(i2c, I2C_INT_TX_EMPTY);
 		k_sem_give(&data->sync_sem);
 	}
+
+#ifdef CONFIG_PM_DEVICE
+	data->store_buf.i2c_reg[8] = i2c->IC_INTR_MASK;
+#endif
 }
 #endif
 
@@ -139,6 +143,9 @@ static int i2c_bee_msg_handler(const struct device *dev)
 			}
 
 			I2C_INTConfig(i2c, I2C_INT_RX_FULL | I2C_INT_TX_ABRT, ENABLE);
+#ifdef CONFIG_PM_DEVICE
+			data->store_buf.i2c_reg[8] = i2c->IC_INTR_MASK;
+#endif
 
 			/* wait for interrupt */
 #if defined(CONFIG_I2C_BEE_INTERRUPT)
@@ -164,6 +171,10 @@ static int i2c_bee_msg_handler(const struct device *dev)
 				I2C_INTConfig(i2c, I2C_INT_RX_FULL, DISABLE);
 				I2C_ClearINTPendingBit(i2c, I2C_INT_RX_FULL);
 			}
+
+#ifdef CONFIG_PM_DEVICE
+			data->store_buf.i2c_reg[8] = i2c->IC_INTR_MASK;
+#endif
 #endif
 
 			if (data->errs != I2C_Success) {
@@ -192,6 +203,9 @@ static int i2c_bee_msg_handler(const struct device *dev)
 
 			I2C_INTConfig(i2c, I2C_INT_TX_EMPTY | I2C_INT_TX_ABRT, ENABLE);
 
+#ifdef CONFIG_PM_DEVICE
+			data->store_buf.i2c_reg[8] = i2c->IC_INTR_MASK;
+#endif
 			/* wait for interrupt */
 #if defined(CONFIG_I2C_BEE_INTERRUPT)
 			k_sem_take(&data->sync_sem, K_FOREVER);
@@ -217,6 +231,10 @@ static int i2c_bee_msg_handler(const struct device *dev)
 				I2C_INTConfig(i2c, I2C_INT_TX_EMPTY, DISABLE);
 				I2C_ClearINTPendingBit(i2c, I2C_INT_TX_EMPTY);
 			}
+
+#ifdef CONFIG_PM_DEVICE
+			data->store_buf.i2c_reg[8] = i2c->IC_INTR_MASK;
+#endif
 #endif
 
 			if (data->errs != I2C_Success) {
@@ -226,6 +244,9 @@ static int i2c_bee_msg_handler(const struct device *dev)
 
 		I2C_INTConfig(i2c, I2C_INT_TX_EMPTY | I2C_INT_TX_ABRT, ENABLE);
 
+#ifdef CONFIG_PM_DEVICE
+		data->store_buf.i2c_reg[8] = i2c->IC_INTR_MASK;
+#endif
 		/* wait for interrupt */
 #if defined(CONFIG_I2C_BEE_INTERRUPT)
 		k_sem_take(&data->sync_sem, K_FOREVER);
@@ -249,6 +270,11 @@ static int i2c_bee_msg_handler(const struct device *dev)
 			I2C_INTConfig(i2c, I2C_INT_TX_EMPTY, DISABLE);
 			I2C_ClearINTPendingBit(i2c, I2C_INT_TX_EMPTY);
 		}
+
+#ifdef CONFIG_PM_DEVICE
+		data->store_buf.i2c_reg[8] = i2c->IC_INTR_MASK;
+#endif
+
 #endif
 		if (data->errs != I2C_Success) {
 			return -EIO;
@@ -328,6 +354,10 @@ static int i2c_bee_transfer(const struct device *dev, struct i2c_msg *msgs, uint
 	/* Disable I2C device */
 	I2C_Cmd(i2c, DISABLE);
 
+#ifdef CONFIG_PM_DEVICE
+	data->store_buf.i2c_reg[11] = i2c->IC_ENABLE;
+#endif
+
 	k_sem_give(&data->bus_mutex);
 	return err;
 }
@@ -384,6 +414,11 @@ static int i2c_bee_configure(const struct device *dev, uint32_t dev_config)
 
 	/* Enable i2c device */
 	I2C_Cmd(i2c, ENABLE);
+
+#ifdef CONFIG_PM_DEVICE
+	I2C_DLPSEnter(i2c, &data->store_buf);
+#endif
+
 error:
 	k_sem_give(&data->bus_mutex);
 
@@ -400,9 +435,6 @@ static int i2c_bee_pm_action(const struct device *dev, enum pm_device_action act
 
 	switch (action) {
 	case PM_DEVICE_ACTION_SUSPEND:
-
-		I2C_DLPSEnter(i2c, &data->store_buf);
-
 		/* Move pins to sleep state */
 		err = pinctrl_apply_state(cfg->pcfg, PINCTRL_STATE_SLEEP);
 		if ((err < 0) && (err != -ENOENT)) {

--- a/drivers/input/input_bee_kscan.c
+++ b/drivers/input/input_bee_kscan.c
@@ -182,6 +182,12 @@ static int kscan_bee_init_driver(const struct device *dev, uint32_t scanmode, ui
 
 	KeyScan_Cmd(keyscan, ENABLE);
 
+#ifdef CONFIG_PM_DEVICE
+	struct kscan_bee_data *data = dev->data;
+
+	KEYSCAN_DLPSEnter(keyscan, &data->store_buf);
+#endif
+
 	return 0;
 }
 
@@ -549,8 +555,6 @@ static int kscan_bee_pm_action(const struct device *dev, enum pm_device_action a
 	switch (action) {
 	case PM_DEVICE_ACTION_SUSPEND:
 		const struct pinctrl_state *state;
-
-		KEYSCAN_DLPSEnter((void *)config->reg, &data->store_buf);
 
 		/* Move pins to sleep state */
 #if !CONFIG_BEE_INPUT_KSCAN_AUTOSCAN_MODE

--- a/drivers/ir/ir_bee.c
+++ b/drivers/ir/ir_bee.c
@@ -36,6 +36,11 @@ LOG_MODULE_REGISTER(ir_bee, CONFIG_IR_LOG_LEVEL);
 #define IR_HAS_TX_DMA DT_DMAS_HAS_NAME(DT_NODELABEL(ir), tx)
 #define IR_HAS_RX_DMA DT_DMAS_HAS_NAME(DT_NODELABEL(ir), rx)
 
+#ifdef CONFIG_PM_DEVICE
+extern void IR_DLPSEnter(void *PeriReg, void *StoreBuf);
+extern void IR_DLPSExit(void *PeriReg, void *StoreBuf);
+#endif
+
 #if (IR_HAS_TX_DMA)
 struct tx_stream {
 	const struct device *dma_dev;
@@ -114,7 +119,6 @@ static void ir_bee_dma_rx_cb(const struct device *dma_dev, void *user_data, uint
 	DBG_DIRECT("[%s] line%d", __func__, __LINE__);
 #endif
 	struct device *dev = (struct device *)user_data;
-	const struct ir_bee_config *cfg = dev->config;
 	struct ir_bee_data *data = dev->data;
 	struct ir_event evt;
 
@@ -190,8 +194,12 @@ static int ir_bee_set_freq(const struct device *dev, uint32_t freq, uint8_t duty
 
 static int ir_bee_tx_init(const struct device *dev)
 {
+	const struct ir_bee_config *config = dev->config;
 	struct ir_bee_data *data = dev->data;
+	IR_TypeDef *ir;
 	int err;
+
+	ir = config->ir;
 
 	err = ir_bee_config_tx_pin(dev);
 	if (err < 0) {
@@ -216,6 +224,10 @@ static int ir_bee_tx_init(const struct device *dev)
 	IR_Init(&IR_InitStruct);
 
 	IR_Cmd(IR_MODE_TX, DISABLE);
+
+#ifdef CONFIG_PM_DEVICE
+	IR_DLPSEnter(ir, &data->store_buf);
+#endif
 
 	return 0;
 }
@@ -299,8 +311,12 @@ static int ir_bee_tx(const struct device *dev, const uint32_t *buf, size_t len)
 
 static int ir_bee_rx_init(const struct device *dev)
 {
+	const struct ir_bee_config *config = dev->config;
 	struct ir_bee_data *data = dev->data;
+	IR_TypeDef *ir;
 	int err;
+
+	ir = config->ir;
 
 	err = ir_bee_config_rx_pin(dev);
 	if (err < 0) {
@@ -342,6 +358,10 @@ static int ir_bee_rx_init(const struct device *dev)
 
 	IR_ClearRxFIFO();
 	IR_Cmd(IR_MODE_RX, ENABLE);
+
+#ifdef CONFIG_PM_DEVICE
+	IR_DLPSEnter(ir, &data->store_buf);
+#endif
 
 	return 0;
 }
@@ -479,7 +499,6 @@ static void ir_bee_isr(const struct device *dev)
 	struct ir_bee_data *data = dev->data;
 	uint8_t tx_len = data->tx_len;
 	struct ir_event evt;
-	uint8_t rx_len;
 
 	memset(&evt, 0, sizeof(evt));
 
@@ -508,6 +527,8 @@ static void ir_bee_isr(const struct device *dev)
 	}
 
 #if !IR_HAS_RX_DMA
+	uint8_t rx_len;
+
 	if (IR_GetINTStatus(IR_INT_RF_LEVEL)) {
 		IR_ClearINTPendingBit(IR_INT_RF_LEVEL_CLR);
 
@@ -608,14 +629,8 @@ static int ir_bee_pm_action(const struct device *dev, enum pm_device_action acti
 	IR_TypeDef *ir = config->ir;
 	int err;
 
-	extern void IR_DLPSEnter(void *PeriReg, void *StoreBuf);
-	extern void IR_DLPSExit(void *PeriReg, void *StoreBuf);
-
 	switch (action) {
 	case PM_DEVICE_ACTION_SUSPEND:
-
-		IR_DLPSEnter(ir, &data->store_buf);
-
 		/* Move pins to sleep state */
 		err = pinctrl_apply_state(config->pcfg, PINCTRL_STATE_SLEEP);
 		if ((err < 0) && (err != -ENOENT)) {

--- a/drivers/kscan/kscan_bee.c
+++ b/drivers/kscan/kscan_bee.c
@@ -184,6 +184,12 @@ static int kscan_bee_init_driver(const struct device *dev, uint32_t scanmode, ui
 
 	KeyScan_Cmd(keyscan, ENABLE);
 
+#ifdef CONFIG_PM_DEVICE
+	struct kscan_bee_data *data = dev->data;
+
+	KEYSCAN_DLPSEnter(keyscan, &data->store_buf);
+#endif
+
 	return 0;
 }
 
@@ -584,8 +590,6 @@ static int kscan_bee_pm_action(const struct device *dev, enum pm_device_action a
 	switch (action) {
 	case PM_DEVICE_ACTION_SUSPEND:
 		const struct pinctrl_state *state;
-
-		KEYSCAN_DLPSEnter((void *)config->reg, &data->store_buf);
 
 		/* Move pins to sleep state */
 #if !CONFIG_BEE_KSCAN_AUTOSCAN_MODE

--- a/drivers/pwm/pwm_bee.c
+++ b/drivers/pwm/pwm_bee.c
@@ -38,10 +38,10 @@
 LOG_MODULE_REGISTER(pwm_bee, CONFIG_PWM_LOG_LEVEL);
 
 #ifdef CONFIG_PM_DEVICE
-	extern void ENHTIM_DLPSEnter(void *PeriReg, void *StoreBuf);
-	extern void ENHTIM_DLPSExit(void *PeriReg, void *StoreBuf);
-	extern void TIM_DLPSEnter(void *PeriReg, void *StoreBuf);
-	extern void TIM_DLPSExit(void *PeriReg, void *StoreBuf);
+extern void ENHTIM_DLPSEnter(void *PeriReg, void *StoreBuf);
+extern void ENHTIM_DLPSExit(void *PeriReg, void *StoreBuf);
+extern void TIM_DLPSEnter(void *PeriReg, void *StoreBuf);
+extern void TIM_DLPSExit(void *PeriReg, void *StoreBuf);
 #endif
 
 struct pwm_bee_data {
@@ -113,6 +113,10 @@ static int pwm_bee_set_cycles(const struct device *dev, uint32_t channel, uint32
 
 		ENHTIM_Cmd((ENHTIM_TypeDef *)timer_base, DISABLE);
 		ENHTIM_Cmd((ENHTIM_TypeDef *)timer_base, ENABLE);
+
+#ifdef CONFIG_PM_DEVICE
+		ENHTIM_DLPSEnter(timer_base, &data->store_buf);
+#endif
 	} else {
 		if (flags & PWM_POLARITY_INVERTED) {
 			if (period_cycles == 0U || pulse_cycles == 0U) {
@@ -140,6 +144,10 @@ static int pwm_bee_set_cycles(const struct device *dev, uint32_t channel, uint32
 		}
 		TIM_Cmd((TIM_TypeDef *)timer_base, DISABLE);
 		TIM_Cmd((TIM_TypeDef *)timer_base, ENABLE);
+
+#ifdef CONFIG_PM_DEVICE
+		TIM_DLPSEnter(timer_base, &data->store_buf);
+#endif
 	}
 
 #ifdef CONFIG_PM_DEVICE
@@ -173,13 +181,6 @@ static int pwm_bee_pm_action(const struct device *dev, enum pm_device_action act
 
 	switch (action) {
 	case PM_DEVICE_ACTION_SUSPEND:
-
-		if (config->is_enhanced) {
-			ENHTIM_DLPSEnter(timer_base, &data->store_buf);
-		} else {
-			TIM_DLPSEnter(timer_base, &data->store_buf);
-		}
-
 		/* Move pins to sleep state */
 		err = pinctrl_apply_state(config->pcfg, PINCTRL_STATE_SLEEP);
 		if (err == -ENOENT) {
@@ -317,6 +318,9 @@ static int pwm_bee_init(const struct device *dev)
 		enh_tim_init_struct.ENHTIM_MaxCount = UINT32_MAX;
 		enh_tim_init_struct.ENHTIM_CCValue = UINT32_MAX;
 		ENHTIM_Init((ENHTIM_TypeDef *)timer_base, &enh_tim_init_struct);
+#ifdef CONFIG_PM_DEVICE
+		ENHTIM_DLPSEnter(timer_base, &data->store_buf);
+#endif
 	} else {
 		TIM_TimeBaseInitTypeDef timer_init_struct;
 		TIM_StructInit(&timer_init_struct);
@@ -330,6 +334,9 @@ static int pwm_bee_init(const struct device *dev)
 		timer_init_struct.TIM_PWM_High_Count = 0;
 		timer_init_struct.TIM_PWM_Low_Count = UINT32_MAX;
 		TIM_TimeBaseInit((TIM_TypeDef *)timer_base, &timer_init_struct);
+#ifdef CONFIG_PM_DEVICE
+		TIM_DLPSEnter(timer_base, &data->store_buf);
+#endif
 	}
 
 	return 0;

--- a/drivers/pwm/pwm_bee.c
+++ b/drivers/pwm/pwm_bee.c
@@ -44,9 +44,7 @@ LOG_MODULE_REGISTER(pwm_bee, CONFIG_PWM_LOG_LEVEL);
 	extern void TIM_DLPSExit(void *PeriReg, void *StoreBuf);
 #endif
 
-/** PWM data. */
 struct pwm_bee_data {
-	/** Timer clock (Hz). */
 	uint32_t tim_clk;
 #ifdef CONFIG_PM_DEVICE
 	union {
@@ -57,7 +55,6 @@ struct pwm_bee_data {
 #endif
 };
 
-/** PWM configuration. */
 struct pwm_bee_config {
 	uint32_t reg;
 	uint8_t channels;

--- a/drivers/rtc/rtc_bee.c
+++ b/drivers/rtc/rtc_bee.c
@@ -453,7 +453,6 @@ static void irq_handler(void)
 		/* updata tm */
 		if (data->last_update_rtc_cnt != UINT32_MAX) {
 			/* first time enter isr after set time */
-
 			data->last_update_time_sec += cnt2sec(dev, ~data->last_update_rtc_cnt);
 
 			data->last_update_rtc_cnt = UINT32_MAX;

--- a/drivers/sdhc/sdhc_bee.c
+++ b/drivers/sdhc/sdhc_bee.c
@@ -540,9 +540,6 @@ static int sdhc_bee_do_transaction(const struct device *dev, struct sdhc_command
 	return ret;
 }
 
-/*
- * Set SDHC io properties
- */
 static int sdhc_bee_set_io(const struct device *dev, struct sdhc_io *ios)
 {
 	const struct sdhc_bee_config *cfg = dev->config;
@@ -628,9 +625,6 @@ static int sdhc_bee_set_io(const struct device *dev, struct sdhc_io *ios)
 	return 0;
 }
 
-/*
- * Send CMD or CMD/DATA via SDHC
- */
 static int sdhc_bee_request(const struct device *dev, struct sdhc_command *cmd,
 			    struct sdhc_data *data)
 {
@@ -659,9 +653,6 @@ static int sdhc_bee_request(const struct device *dev, struct sdhc_command *cmd,
 	return ret;
 }
 
-/*
- * Reset SDHC controller
- */
 static int sdhc_bee_reset(const struct device *dev)
 {
 	const struct sdhc_bee_config *cfg = dev->config;
@@ -672,17 +663,11 @@ static int sdhc_bee_reset(const struct device *dev)
 	return 0;
 }
 
-/*
- * Get card presence
- */
 static int sdhc_bee_get_card_present(const struct device *dev)
 {
 	return 1;
 }
 
-/*
- * Return 0 if card is not busy, 1 if it is
- */
 static int sdhc_bee_card_busy(const struct device *dev)
 {
 	const struct sdhc_bee_config *cfg = dev->config;
@@ -691,9 +676,6 @@ static int sdhc_bee_card_busy(const struct device *dev)
 	return false;
 }
 
-/*
- * Get host properties
- */
 static int sdhc_bee_get_host_props(const struct device *dev, struct sdhc_host_props *props)
 {
 	const struct sdhc_bee_config *cfg = dev->config;
@@ -756,12 +738,6 @@ static int sdhc_bee_disable_interrupt(const struct device *dev, int sources)
 	return 0;
 }
 
-/**
- * @brief SDHC interrupt handler
- *
- * All communication is handled by the hardware automatically,
- * so the isr just handles error status.
- */
 static void sdio_bee_isr(void *arg)
 {
 	const struct device *dev = (const struct device *)arg;
@@ -777,9 +753,6 @@ static void sdio_bee_isr(void *arg)
 	}
 }
 
-/*
- * Perform early system init for SDHC
- */
 static int sdhc_bee_init(const struct device *dev)
 {
 	const struct sdhc_bee_config *cfg = dev->config;

--- a/drivers/sensor/qdec_bee/qdec_bee.c
+++ b/drivers/sensor/qdec_bee/qdec_bee.c
@@ -28,8 +28,8 @@ LOG_MODULE_REGISTER(qdec_bee, CONFIG_SENSOR_LOG_LEVEL);
 #define MAX_ACC_CNT_BITS 16
 
 #ifdef CONFIG_PM_DEVICE
-	extern void QDEC_DLPSEnter(void *PeriReg, void *StoreBuf);
-	extern void QDEC_DLPSExit(void *PeriReg, void *StoreBuf);
+extern void QDEC_DLPSEnter(void *PeriReg, void *StoreBuf);
+extern void QDEC_DLPSExit(void *PeriReg, void *StoreBuf);
 #endif
 
 struct qdec_bee_axis_data {
@@ -255,6 +255,9 @@ static int qdec_bee_trigger_set(const struct device *dev, const struct sensor_tr
 #endif
 	}
 
+#ifdef CONFIG_PM_DEVICE
+	data->store_buf.qdec_reg[4] = qdec->INT_MASK;
+#endif
 	return 0;
 }
 
@@ -351,7 +354,6 @@ static int qdec_bee_pm_action(const struct device *dev, enum pm_device_action ac
 
 	switch (action) {
 	case PM_DEVICE_ACTION_SUSPEND:
-		QDEC_DLPSEnter(qdec, &data->store_buf);
 #if CONFIG_BEE_QDEC_X_AXIS_ENABLE
 		acc_cnt = QDEC_GetAxisCount(qdec, QDEC_AXIS_X);
 		data->x.pm_acc = data->x.round * 65536 + acc_cnt + data->x.pm_acc;
@@ -493,6 +495,10 @@ static int qdec_bee_init(const struct device *dev)
 	QDEC_INTConfig(qdec, QDEC_Z_INT_NEW_DATA, ENABLE);
 	QDEC_INTConfig(qdec, QDEC_Z_INT_ILLEGAL, ENABLE);
 	QDEC_Cmd(qdec, QDEC_AXIS_Z, ENABLE);
+#endif
+
+#ifdef CONFIG_PM_DEVICE
+	QDEC_DLPSEnter(qdec, &data->store_buf);
 #endif
 
 	config->irq_connect();

--- a/drivers/serial/uart_bee.c
+++ b/drivers/serial/uart_bee.c
@@ -38,11 +38,17 @@
 #endif
 
 #if defined(CONFIG_SOC_SERIES_RTL87X2G)
-#define BEE_UART_REG_RB_THR UART_RBR_THR
-#define BEE_UART_REG_MISCR  UART_MISCR
+#define BEE_UART_REG_RB_THR        UART_RBR_THR
+#define BEE_UART_REG_MISCR         UART_MISCR
+#define BEE_UART_REG_DLM_IER       UART_DLM_IER
+#define BEE_UART_REG_RX_TIMEOUT    UART_RX_TIMEOUT
+#define BEE_UART_REG_RX_TIMEOUT_EN UART_RX_TIMEOUT_EN
 #elif defined(CONFIG_SOC_SERIES_RTL8752H)
-#define BEE_UART_REG_RB_THR RB_THR
-#define BEE_UART_REG_MISCR  MISCR
+#define BEE_UART_REG_RB_THR        RB_THR
+#define BEE_UART_REG_MISCR         MISCR
+#define BEE_UART_REG_DLM_IER       DLH_INTCR
+#define BEE_UART_REG_RX_TIMEOUT    RX_IDLE_TOCR
+#define BEE_UART_REG_RX_TIMEOUT_EN RX_IDLE_INTCR
 #endif
 
 #include <zephyr/logging/log.h>
@@ -63,8 +69,8 @@ static const struct device *const devices[] = {
 #endif
 
 #ifdef CONFIG_PM_DEVICE
-	extern void UART_DLPSEnter(void *PeriReg, void *StoreBuf);
-	extern void UART_DLPSExit(void *PeriReg, void *StoreBuf);
+extern void UART_DLPSEnter(void *PeriReg, void *StoreBuf);
+extern void UART_DLPSExit(void *PeriReg, void *StoreBuf);
 #endif
 
 static const uint32_t RTL_UART_BAUDRATE_TABLE[][3] = {
@@ -209,6 +215,9 @@ static int uart_bee_configure(const struct device *dev, const struct uart_config
 #endif
 
 	UART_Init(uart, &uart_init_struct);
+#ifdef CONFIG_PM_DEVICE
+	UART_DLPSEnter(uart, &data->store_buf);
+#endif
 
 	data->uart_config = *cfg;
 	return 0;
@@ -348,6 +357,10 @@ static void uart_bee_irq_tx_disable(const struct device *dev)
 
 	data->tx_int_en = false;
 	UART_INTConfig(uart, UART_INT_TX_FIFO_EMPTY, DISABLE);
+
+#ifdef CONFIG_PM_DEVICE
+	data->store_buf.uart_reg[2] = uart->BEE_UART_REG_DLM_IER;
+#endif
 }
 
 static int uart_bee_irq_tx_ready(const struct device *dev)
@@ -380,6 +393,12 @@ static void uart_bee_irq_rx_enable(const struct device *dev)
 	data->rx_int_en = true;
 	UART_INTConfig(uart, UART_INT_RD_AVA, ENABLE);
 	UART_INTConfig(uart, UART_INT_RX_IDLE, ENABLE);
+
+#ifdef CONFIG_PM_DEVICE
+	data->store_buf.uart_reg[2] = uart->BEE_UART_REG_DLM_IER;
+	data->store_buf.uart_reg[8] = uart->BEE_UART_REG_RX_TIMEOUT;
+	data->store_buf.uart_reg[9] = uart->BEE_UART_REG_RX_TIMEOUT_EN;
+#endif
 }
 
 static void uart_bee_irq_rx_disable(const struct device *dev)
@@ -395,6 +414,12 @@ static void uart_bee_irq_rx_disable(const struct device *dev)
 	data->rx_int_en = false;
 	UART_INTConfig(uart, UART_INT_RD_AVA, DISABLE);
 	UART_INTConfig(uart, UART_INT_RX_IDLE, DISABLE);
+
+#ifdef CONFIG_PM_DEVICE
+	data->store_buf.uart_reg[2] = uart->BEE_UART_REG_DLM_IER;
+	data->store_buf.uart_reg[8] = uart->BEE_UART_REG_RX_TIMEOUT;
+	data->store_buf.uart_reg[9] = uart->BEE_UART_REG_RX_TIMEOUT_EN;
+#endif
 }
 
 static int uart_bee_irq_rx_ready(const struct device *dev)
@@ -424,24 +449,38 @@ static void uart_bee_irq_err_enable(const struct device *dev)
 {
 	const struct uart_bee_config *config = dev->config;
 	UART_TypeDef *uart = config->uart;
+	struct uart_bee_data *data;
+
+	data = dev->data;
 
 #if DBG_DIRECT_SHOW
 	DBG_DIRECT("[%s]", __func__);
 #endif
 
 	UART_INTConfig(uart, UART_INT_RX_LINE_STS, ENABLE);
+
+#ifdef CONFIG_PM_DEVICE
+	data->store_buf.uart_reg[2] = uart->BEE_UART_REG_DLM_IER;
+#endif
 }
 
 static void uart_bee_irq_err_disable(const struct device *dev)
 {
 	const struct uart_bee_config *config = dev->config;
 	UART_TypeDef *uart = config->uart;
+	struct uart_bee_data *data;
+
+	data = dev->data;
 
 #if DBG_DIRECT_SHOW
 	DBG_DIRECT("[%s]", __func__);
 #endif
 
 	UART_INTConfig(uart, UART_INT_RX_LINE_STS, DISABLE);
+
+#ifdef CONFIG_PM_DEVICE
+	data->store_buf.uart_reg[2] = uart->BEE_UART_REG_DLM_IER;
+#endif
 }
 
 static int uart_bee_irq_is_pending(const struct device *dev)
@@ -637,6 +676,10 @@ static inline void uart_bee_dma_tx_enable(const struct device *dev)
 
 	uart->BEE_UART_REG_MISCR &= ~(0x1f << 3);
 	uart->BEE_UART_REG_MISCR |= ((16 - data->dma_tx.dma_cfg.dest_burst_length) << 3) | BIT(1);
+
+#ifdef CONFIG_PM_DEVICE
+	data->store_buf.uart_reg[10] = uart->BEE_UART_REG_MISCR;
+#endif
 }
 
 static inline void uart_bee_dma_tx_disable(const struct device *dev)
@@ -646,8 +689,15 @@ static inline void uart_bee_dma_tx_disable(const struct device *dev)
 #endif
 	const struct uart_bee_config *config = dev->config;
 	UART_TypeDef *uart = config->uart;
+	struct uart_bee_data *data;
+
+	data = dev->data;
 
 	uart->BEE_UART_REG_MISCR &= ~BIT(1);
+
+#ifdef CONFIG_PM_DEVICE
+	data->store_buf.uart_reg[10] = uart->BEE_UART_REG_MISCR;
+#endif
 }
 
 static inline void uart_bee_dma_rx_enable(const struct device *dev)
@@ -662,6 +712,10 @@ static inline void uart_bee_dma_rx_enable(const struct device *dev)
 	uart->BEE_UART_REG_MISCR &= ~(0x3f << 8);
 	uart->BEE_UART_REG_MISCR |= ((data->dma_rx.dma_cfg.source_burst_length) << 8) | BIT(2);
 
+#ifdef CONFIG_PM_DEVICE
+	data->store_buf.uart_reg[10] = uart->BEE_UART_REG_MISCR;
+#endif
+
 	data->dma_rx.enabled = true;
 }
 
@@ -675,6 +729,10 @@ static inline void uart_bee_dma_rx_disable(const struct device *dev)
 	UART_TypeDef *uart = config->uart;
 
 	uart->BEE_UART_REG_MISCR &= ~BIT(2);
+
+#ifdef CONFIG_PM_DEVICE
+	data->store_buf.uart_reg[10] = uart->BEE_UART_REG_MISCR;
+#endif
 
 	data->dma_rx.enabled = false;
 }
@@ -928,6 +986,12 @@ static int uart_bee_async_rx_enable(const struct device *dev, uint8_t *rx_buf, s
 	UART_INTConfig(uart, UART_INT_RX_IDLE, DISABLE);
 	UART_INTConfig(uart, UART_INT_RX_IDLE, ENABLE);
 
+#ifdef CONFIG_PM_DEVICE
+	data->store_buf.uart_reg[2] = uart->BEE_UART_REG_DLM_IER;
+	data->store_buf.uart_reg[8] = uart->BEE_UART_REG_RX_TIMEOUT;
+	data->store_buf.uart_reg[9] = uart->BEE_UART_REG_RX_TIMEOUT_EN;
+#endif
+
 	if (dma_start(data->dma_rx.dma_dev, data->dma_rx.dma_channel)) {
 		LOG_ERR("UART ERR: RX DMA start failed!");
 		return -EFAULT;
@@ -971,6 +1035,11 @@ static int uart_bee_async_rx_disable(const struct device *dev)
 	}
 
 	UART_INTConfig(uart, UART_INT_RX_IDLE, DISABLE);
+
+#ifdef CONFIG_PM_DEVICE
+	data->store_buf.uart_reg[8] = uart->BEE_UART_REG_RX_TIMEOUT;
+	data->store_buf.uart_reg[9] = uart->BEE_UART_REG_RX_TIMEOUT_EN;
+#endif
 
 	/* uart_bee_dma_rx_flush(dev);*/
 
@@ -1220,9 +1289,6 @@ static int uart_bee_pm_action(const struct device *dev, enum pm_device_action ac
 
 	switch (action) {
 	case PM_DEVICE_ACTION_SUSPEND:
-
-		UART_DLPSEnter(uart, &data->store_buf);
-
 		/* Move pins to sleep state */
 		err = pinctrl_apply_state(config->pcfg, PINCTRL_STATE_SLEEP);
 		if ((err < 0) && (err != -ENOENT)) {

--- a/drivers/serial/uart_bee.c
+++ b/drivers/serial/uart_bee.c
@@ -6,11 +6,6 @@
 
 #define DT_DRV_COMPAT realtek_bee_uart
 
-/**
- * @brief Driver for UART port on BEE family processor.
- * @note  Please validate for newly added series.
- */
-
 #include <zephyr/kernel.h>
 #include <zephyr/arch/cpu.h>
 #include <zephyr/sys/__assert.h>
@@ -296,8 +291,6 @@ static int uart_bee_fifo_fill(const struct device *dev, const uint8_t *tx_data, 
 	if (!(UART_GetTxFIFODataLen(uart) < UART_TX_FIFO_SIZE)) {
 		return num_tx;
 	}
-
-	/* Lock interrupts to prevent nested interrupts or thread switch */
 
 	key = irq_lock();
 
@@ -776,10 +769,7 @@ void uart_bee_dma_rx_cb(const struct device *dma_dev, void *user_data, uint32_t 
 #endif
 		async_evt_rx_buf_release(data);
 
-		/* replace the buffer when the current
-		 * is full and not the same as the next
-		 * one.
-		 */
+		/* replace the buffer when the current is full and not the same as the next one. */
 		uart_bee_dma_replace_buffer(uart_dev);
 	} else {
 #if DBG_DIRECT_SHOW
@@ -1002,8 +992,6 @@ static int uart_bee_async_rx_disable(const struct device *dev)
 
 	data->rx_next_buffer = NULL;
 	data->rx_next_buffer_len = 0;
-
-	/* When async rx is disabled, enable interruptible instance of uart to function normally */
 
 	LOG_DBG("rx: disabled");
 
@@ -1324,16 +1312,6 @@ static const struct uart_driver_api uart_bee_driver_api = {
 #endif
 };
 
-/**
- * @brief Initialize UART channel
- *
- * This routine is called to reset the chip in a quiescent state.
- * It is assumed that this function is called only once per UART.
- *
- * @param dev UART device struct
- *
- * @return 0
- */
 static int uart_bee_init(const struct device *dev)
 {
 	const struct uart_bee_config *config = dev->config;
@@ -1346,7 +1324,6 @@ static int uart_bee_init(const struct device *dev)
 	data->dev = dev;
 
 	/* Configure pinmux  */
-
 	err = pinctrl_apply_state(config->pcfg, PINCTRL_STATE_DEFAULT);
 	if (err < 0) {
 		return err;
@@ -1355,7 +1332,6 @@ static int uart_bee_init(const struct device *dev)
 	(void)clock_control_on(BEE_CLOCK_CONTROLLER, (clock_control_subsys_t)&config->clkid);
 
 	/* Configure peripheral  */
-
 	err = uart_bee_configure(dev, &data->uart_config);
 	if (err) {
 		return err;

--- a/drivers/serial/uart_bee.h
+++ b/drivers/serial/uart_bee.h
@@ -4,11 +4,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-/**
- * @brief Driver for UART port on BEE family processor.
- *
- */
-
 #ifndef ZEPHYR_DRIVERS_SERIAL_UART_BEE_H_
 #define ZEPHYR_DRIVERS_SERIAL_UART_BEE_H_
 
@@ -54,7 +49,6 @@ struct uart_bee_config {
 #endif
 };
 
-/* driver data */
 #ifdef CONFIG_UART_ASYNC_API
 struct uart_dma_stream {
 	const struct device *dma_dev;


### PR DESCRIPTION
Store adc/counter/gpio/i2c/kscan/ir/pwm/qdec/uart registers immediately after operating instead of store all registers in pm suspend action to reduce store stage time.