### PR TITLE
drivers: gpio: config pinmux in resume action

### DIFF
--- a/drivers/gpio/gpio_rtl87x2g.c
+++ b/drivers/gpio/gpio_rtl87x2g.c
@@ -537,6 +537,9 @@ static int gpio_rtl87x2g_pm_action(const struct device *port,
 	case PM_DEVICE_ACTION_RESUME:
 
 		while (cur_output_pad_node->next_gpio_num != 0xff) {
+			Pinmux_Config(
+			pm_pad_node_array[cur_output_pad_node->next_gpio_num].pad_num,
+			DWGPIO);
 			Pad_SetControlMode(
 			pm_pad_node_array[cur_output_pad_node->next_gpio_num].pad_num,
 			PAD_PINMUX_MODE);
@@ -545,6 +548,9 @@ static int gpio_rtl87x2g_pm_action(const struct device *port,
 		}
 
 		while (cur_wakeup_pad_node->next_gpio_num != 0xff) {
+			Pinmux_Config(
+			pm_pad_node_array[cur_wakeup_pad_node->next_gpio_num].pad_num,
+			DWGPIO);
 			Pad_SetControlMode(
 			pm_pad_node_array[cur_wakeup_pad_node->next_gpio_num].pad_num,
 			PAD_PINMUX_MODE);

--- a/modules/Kconfig.realtek
+++ b/modules/Kconfig.realtek
@@ -75,7 +75,7 @@ config USE_HAL_REALTEK_SPI
 	  Enable HAL REALTEK SPI driver
 
 config USE_HAL_REALTEK_SPI3W
-	bool "enable realtek spi3w"
+	bool "Realtek spi3w"
 	help
 	  Enable HAL REALTEK SPI3W driver
 


### PR DESCRIPTION
Configure pad as gpio function in resume action.