### PR TITLE
drivers: pwm: add rtl87x2j pwm driver

### DIFF
--- a/drivers/pwm/pwm_bee.c
+++ b/drivers/pwm/pwm_bee.c
@@ -41,17 +41,35 @@ static int pwm_bee_set_cycles(const struct device *dev, uint32_t channel, uint32
 	ARG_UNUSED(channel);
 	const struct pwm_bee_config *config = dev->config;
 	struct pwm_bee_data *data = dev->data;
+	enum bee_pwm_output_mode output_mode;
+	const struct pinctrl_state *state;
+	int err;
 
 	LOG_DBG("channel=%d, period_cycles=%x, pulse_cycles=%x, flags=%x", channel, period_cycles,
 		pulse_cycles, flags);
+
+	err = pinctrl_lookup_state(config->pcfg, PINCTRL_STATE_DEFAULT, &state);
+	if (err < 0) {
+		return err;
+	}
 
 	if (!data->ops) {
 		return -ENOTSUP;
 	}
 
-	data->ops->set_pwm_duty(config->reg, period_cycles, pulse_cycles,
-				(flags & PWM_POLARITY_INVERTED));
+	output_mode = data->ops->set_pwm_duty(config->reg, period_cycles, pulse_cycles,
+					      (flags & PWM_POLARITY_INVERTED));
 
+	if (output_mode != BEE_PWM_OUTPUT_MODE_TIMER) {
+		Pad_Config(state->pins[0].pin, PAD_SW_MODE, PAD_IS_PWRON, PAD_PULL_NONE,
+			   PAD_OUT_ENABLE,
+			   output_mode == BEE_PWM_OUTPUT_MODE_HIGH ? PAD_OUT_HIGH : PAD_OUT_LOW);
+		data->ops->stop(config->reg);
+		return 0;
+	}
+
+	Pad_Config(state->pins[0].pin, PAD_PINMUX_MODE, PAD_IS_PWRON, PAD_PULL_NONE,
+		   PAD_OUT_DISABLE, PAD_OUT_LOW);
 	data->ops->stop(config->reg);
 	data->ops->start(config->reg);
 
@@ -106,6 +124,9 @@ static DEVICE_API(pwm, pwm_bee_driver_api) = {
 #elif defined(CONFIG_SOC_SERIES_RTL8752H)
 #define TIMER_DIV_CONFIG(index)                                                                    \
 	.clock_div = CONCAT(TIM_CLOCK_DIVIDER_, DT_PROP(PWM_BEE_PARENT_NODE(index), prescaler))
+#elif defined(CONFIG_SOC_SERIES_RTL87X2J)
+#define TIMER_DIV_CONFIG(index)                                                                    \
+	.clock_div = CONCAT(TIMER_CLOCK_DIV_, DT_PROP(PWM_BEE_PARENT_NODE(index), prescaler))
 #endif
 
 #define PWM_BEE_INIT(index)                                                                        \

--- a/dts/arm/realtek/bee/rtl87x2j.dtsi
+++ b/dts/arm/realtek/bee/rtl87x2j.dtsi
@@ -235,6 +235,12 @@
 				compatible = "realtek,bee-counter-timer";
 				status = "disabled";
 			};
+
+			pwm {
+				compatible = "realtek,bee-pwm";
+				status = "disabled";
+				#pwm-cells = <3>;
+			};
 		};
 
 		timer1: timer@40024050 {
@@ -247,6 +253,12 @@
 			counter {
 				compatible = "realtek,bee-counter-timer";
 				status = "disabled";
+			};
+
+			pwm {
+				compatible = "realtek,bee-pwm";
+				status = "disabled";
+				#pwm-cells = <3>;
 			};
 		};
 
@@ -261,6 +273,12 @@
 				compatible = "realtek,bee-counter-timer";
 				status = "disabled";
 			};
+
+			pwm {
+				compatible = "realtek,bee-pwm";
+				status = "disabled";
+				#pwm-cells = <3>;
+			};
 		};
 
 		timer3: timer@400240f0 {
@@ -273,6 +291,12 @@
 			counter {
 				compatible = "realtek,bee-counter-timer";
 				status = "disabled";
+			};
+
+			pwm {
+				compatible = "realtek,bee-pwm";
+				status = "disabled";
+				#pwm-cells = <3>;
 			};
 		};
 
@@ -287,6 +311,12 @@
 				compatible = "realtek,bee-counter-timer";
 				status = "disabled";
 			};
+
+			pwm {
+				compatible = "realtek,bee-pwm";
+				status = "disabled";
+				#pwm-cells = <3>;
+			};
 		};
 
 		timer5: timer@40024190 {
@@ -299,6 +329,12 @@
 			counter {
 				compatible = "realtek,bee-counter-timer";
 				status = "disabled";
+			};
+
+			pwm {
+				compatible = "realtek,bee-pwm";
+				status = "disabled";
+				#pwm-cells = <3>;
 			};
 		};
 
@@ -313,6 +349,12 @@
 				compatible = "realtek,bee-counter-timer";
 				status = "disabled";
 			};
+
+			pwm {
+				compatible = "realtek,bee-pwm";
+				status = "disabled";
+				#pwm-cells = <3>;
+			};
 		};
 
 		timer7: timer@40024230 {
@@ -325,6 +367,12 @@
 			counter {
 				compatible = "realtek,bee-counter-timer";
 				status = "disabled";
+			};
+
+			pwm {
+				compatible = "realtek,bee-pwm";
+				status = "disabled";
+				#pwm-cells = <3>;
 			};
 		};
 
@@ -339,6 +387,12 @@
 				compatible = "realtek,bee-counter-timer";
 				status = "disabled";
 			};
+
+			pwm {
+				compatible = "realtek,bee-pwm";
+				status = "disabled";
+				#pwm-cells = <3>;
+			};
 		};
 
 		timer9: timer@40018000 {
@@ -351,6 +405,12 @@
 			counter {
 				compatible = "realtek,bee-counter-timer";
 				status = "disabled";
+			};
+
+			pwm {
+				compatible = "realtek,bee-pwm";
+				status = "disabled";
+				#pwm-cells = <3>;
 			};
 		};
 

--- a/soc/realtek/bee/common/bee_timer_common.c
+++ b/soc/realtek/bee/common/bee_timer_common.c
@@ -82,36 +82,46 @@ static bool basic_tim_int_status(uint32_t reg)
 	return TIM_GetINTStatus((TIM_TypeDef *)reg) ? true : false;
 }
 
-static void basic_tim_set_pwm_duty(uint32_t reg, uint32_t period_cyc, uint32_t pulse_cyc,
-				   bool inverted)
+static enum bee_pwm_output_mode basic_tim_set_pwm_duty(uint32_t reg, uint32_t period_cyc,
+						       uint32_t pulse_cyc, bool inverted)
 {
 	uint32_t high, low;
+	enum bee_pwm_output_mode output_mode = BEE_PWM_OUTPUT_MODE_TIMER;
 
 	/* Basic Timer uses High Count vs Low Count logic */
 	if (inverted) {
 		if (period_cyc == 0U || pulse_cyc == 0U) {
+			output_mode = BEE_PWM_OUTPUT_MODE_HIGH;
 			high = UINT32_MAX;
 			low = 0; /* duty = 0% */
 		} else if (period_cyc == pulse_cyc) {
+			output_mode = BEE_PWM_OUTPUT_MODE_LOW;
 			high = 0;
 			low = UINT32_MAX; /* duty = 100% */
 		} else {
+			output_mode = BEE_PWM_OUTPUT_MODE_TIMER;
 			high = period_cyc - pulse_cyc;
 			low = pulse_cyc;
 		}
 	} else {
 		if (period_cyc == 0U || pulse_cyc == 0U) {
+			output_mode = BEE_PWM_OUTPUT_MODE_LOW;
 			high = 0;
 			low = UINT32_MAX;
 		} else if (period_cyc == pulse_cyc) {
+			output_mode = BEE_PWM_OUTPUT_MODE_HIGH;
 			high = UINT32_MAX;
 			low = 0;
 		} else {
+			output_mode = BEE_PWM_OUTPUT_MODE_TIMER;
 			high = pulse_cyc;
 			low = period_cyc - pulse_cyc;
 		}
 	}
+
 	TIM_PWMChangeFreqAndDuty((TIM_TypeDef *)reg, high, low);
+
+	return output_mode;
 }
 #elif defined(CONFIG_SOC_SERIES_RTL87X2J)
 #define TIMER_MAX_CNT(reg) ((TIMER_TypeDef *)reg)->TIMER_MAX_CNT
@@ -184,37 +194,46 @@ static bool basic_tim_int_status(uint32_t reg)
 	return TIMER_GetINTStatus((TIMER_TypeDef *)reg, TIMER_INT_TIMEOUT) ? true : false;
 }
 
-static void basic_tim_set_pwm_duty(uint32_t reg, uint32_t period_cyc, uint32_t pulse_cyc,
-				   bool inverted)
+static enum bee_pwm_output_mode basic_tim_set_pwm_duty(uint32_t reg, uint32_t period_cyc,
+						       uint32_t pulse_cyc, bool inverted)
 {
 	uint32_t high, low;
+	enum bee_pwm_output_mode output_mode = BEE_PWM_OUTPUT_MODE_TIMER;
 
 	/* Basic Timer uses High Count vs Low Count logic */
 	if (inverted) {
 		if (period_cyc == 0U || pulse_cyc == 0U) {
+			output_mode = BEE_PWM_OUTPUT_MODE_HIGH;
 			high = UINT32_MAX;
 			low = 0; /* duty = 0% */
 		} else if (period_cyc == pulse_cyc) {
+			output_mode = BEE_PWM_OUTPUT_MODE_LOW;
 			high = 0;
 			low = UINT32_MAX; /* duty = 100% */
 		} else {
+			output_mode = BEE_PWM_OUTPUT_MODE_TIMER;
 			high = period_cyc - pulse_cyc;
 			low = pulse_cyc;
 		}
 	} else {
 		if (period_cyc == 0U || pulse_cyc == 0U) {
+			output_mode = BEE_PWM_OUTPUT_MODE_LOW;
 			high = 0;
 			low = UINT32_MAX;
 		} else if (period_cyc == pulse_cyc) {
+			output_mode = BEE_PWM_OUTPUT_MODE_HIGH;
 			high = UINT32_MAX;
 			low = 0;
 		} else {
+			output_mode = BEE_PWM_OUTPUT_MODE_TIMER;
 			high = pulse_cyc;
 			low = period_cyc - pulse_cyc;
 		}
 	}
 
 	TIMER_PWMChangeFreqAndDuty((TIMER_TypeDef *)reg, high + low, high);
+
+	return output_mode;
 }
 #endif
 
@@ -314,30 +333,37 @@ static bool enh_tim_int_status(uint32_t reg)
 	return ENHTIM_GetINTStatus((ENHTIM_TypeDef *)reg, ENHTIM_INT_TIM) ? true : false;
 }
 
-static void enh_tim_set_pwm_duty(uint32_t reg, uint32_t period_cyc, uint32_t pulse_cyc,
-				 bool inverted)
+static enum bee_pwm_output_mode enh_tim_set_pwm_duty(uint32_t reg, uint32_t period_cyc,
+						     uint32_t pulse_cyc, bool inverted)
 {
 	uint32_t cc_val, max_val;
+	enum bee_pwm_output_mode output_mode = BEE_PWM_OUTPUT_MODE_TIMER;
 
 	if (inverted) {
 		if (period_cyc == 0U || pulse_cyc == 0U) {
+			output_mode = BEE_PWM_OUTPUT_MODE_HIGH;
 			max_val = UINT32_MAX - 1;
 			cc_val = 0;
 		} else if (period_cyc == pulse_cyc) {
+			output_mode = BEE_PWM_OUTPUT_MODE_LOW;
 			max_val = UINT32_MAX - 1;
 			cc_val = UINT32_MAX;
 		} else {
+			output_mode = BEE_PWM_OUTPUT_MODE_TIMER;
 			max_val = period_cyc;
 			cc_val = period_cyc - pulse_cyc;
 		}
 	} else {
 		if (period_cyc == 0U || pulse_cyc == 0U) {
+			output_mode = BEE_PWM_OUTPUT_MODE_LOW;
 			max_val = UINT32_MAX - 1;
 			cc_val = UINT32_MAX;
 		} else if (period_cyc == pulse_cyc) {
+			output_mode = BEE_PWM_OUTPUT_MODE_HIGH;
 			max_val = UINT32_MAX - 1;
 			cc_val = 0;
 		} else {
+			output_mode = BEE_PWM_OUTPUT_MODE_TIMER;
 			max_val = period_cyc;
 			cc_val = pulse_cyc;
 		}
@@ -345,6 +371,8 @@ static void enh_tim_set_pwm_duty(uint32_t reg, uint32_t period_cyc, uint32_t pul
 
 	ENHTIM_SetMaxCount((ENHTIM_TypeDef *)reg, max_val);
 	ENHTIM_SetCCValue((ENHTIM_TypeDef *)reg, cc_val);
+
+	return output_mode;
 }
 
 static const struct bee_timer_ops bee_enh_ops = {

--- a/soc/realtek/bee/common/bee_timer_common.h
+++ b/soc/realtek/bee/common/bee_timer_common.h
@@ -21,14 +21,17 @@
 #include <rtl_tim.h>
 #include <rtl_enh_tim.h>
 #include <rtl_rcc.h>
+#include <rtl_pinmux.h>
 #elif defined(CONFIG_SOC_SERIES_RTL8752H)
 #include <rtl876x_tim.h>
 #include <rtl876x_enh_tim.h>
 #include <rtl876x_rcc.h>
 #include <rtl876x_nvic.h>
 #include <vector_table.h>
+#include <rtl876x_pinmux.h>
 #elif defined(CONFIG_SOC_SERIES_RTL87X2J)
 #include <rtl_timer.h>
+#include <rtl_pinmux.h>
 #else
 #error "Unsupported Realtek Bee SoC series"
 #endif
@@ -47,6 +50,18 @@ enum bee_timer_mode {
 	BEE_TIMER_MODE_COUNTER,
 	/** Mode for Zephyr PWM driver (Pulse Width Modulation). */
 	BEE_TIMER_MODE_PWM,
+};
+
+/**
+ * @brief Bee PWM Output Modes.
+ */
+enum bee_pwm_output_mode {
+	/** PWM output controlled by timer (normal PWM mode). */
+	BEE_PWM_OUTPUT_MODE_TIMER,
+	/** PWM output forced to low level. */
+	BEE_PWM_OUTPUT_MODE_LOW,
+	/** PWM output forced to high level. */
+	BEE_PWM_OUTPUT_MODE_HIGH,
 };
 
 /**
@@ -105,8 +120,11 @@ struct bee_timer_ops {
 	 * @param period_cyc Total cycle count for the period.
 	 * @param pulse_cyc Active pulse width in cycles.
 	 * @param inverted If true, the polarity is inverted.
+	 * @return The actual PWM output mode used (may differ from timer mode if duty cycle
+	 *         is 0% or 100%).
 	 */
-	void (*set_pwm_duty)(uint32_t reg, uint32_t period_cyc, uint32_t pulse_cyc, bool inverted);
+	enum bee_pwm_output_mode (*set_pwm_duty)(uint32_t reg, uint32_t period_cyc,
+						 uint32_t pulse_cyc, bool inverted);
 
 	/**
 	 * @brief Enable the timer interrupt.

--- a/tests/drivers/i2c/i2c_api/boards/rtl87x2j_evb_rtl8762jth.overlay
+++ b/tests/drivers/i2c/i2c_api/boards/rtl87x2j_evb_rtl8762jth.overlay
@@ -1,0 +1,29 @@
+/*
+ * Copyright (c) 2026, Realtek Semiconductor Corporation
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/ {
+	aliases {
+		i2c-0 = &i2c0;
+	};
+};
+
+&i2c0 {
+	pinctrl-0 = <&i2c0_default>;
+	pinctrl-names = "default";
+	status = "okay";
+};
+
+&pinctrl {
+	i2c0_default: i2c0_default {
+		group1 {
+			psels = <BEE_PSEL(I2C0_CLK, P2_2)>,
+				<BEE_PSEL(I2C0_DAT, P2_3)>;
+			output-enable;
+			output-high;
+			bias-pull-up;
+		};
+	};
+};

--- a/tests/drivers/pwm/pwm_api/boards/rtl87x2j_evb_rtl8762jth.overlay
+++ b/tests/drivers/pwm/pwm_api/boards/rtl87x2j_evb_rtl8762jth.overlay
@@ -1,0 +1,35 @@
+/*
+ * Copyright (c) 2026, Realtek Semiconductor Corporation
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <zephyr/dt-bindings/pwm/pwm.h>
+
+/ {
+	aliases {
+		pwm-test = &pwm2;
+	};
+};
+
+&timer2 {
+	status = "okay";
+	prescaler = <1>;
+
+	pwm2: pwm {
+		status = "okay";
+		pinctrl-0 = <&pwm2_default>;
+		pinctrl-names = "default";
+	};
+};
+
+&pinctrl {
+	pwm2_default: pwm2_default {
+		group1 {
+			psels = <BEE_PSEL(PWM2, P0_1)>;
+			output-enable;
+			output-low;
+			bias-pull-down;
+		};
+	};
+};


### PR DESCRIPTION
Since there is no pwm_stop API, after PWM is enabled, qactive remains high, which prevents the timer clock from being gated.

To reduce power consumption, update set_cycles so that for empty/full duty cycles the timer is disabled and the pad output is configured directly. This allows the timer to be automatically clock gated.

This logic is shared by rtl87x2g and rtl8752h.
