### PR TITLE
soc: realtek: bee: fix LTO causing image header corruption

### DIFF
--- a/soc/realtek/bee/rtl8752h/bee_image_header.c
+++ b/soc/realtek/bee/rtl8752h/bee_image_header.c
@@ -11,7 +11,8 @@
 
 extern void z_arm_reset(void);
 
-const T_IMG_HEADER_FORMAT img_header __attribute__((section(".image_header"))) = {
+const T_IMG_HEADER_FORMAT img_header __attribute__((section(".image_header")))
+	__attribute__((used)) = {
 	.auth = {
 			.image_mac = {[0 ... 15] = 0xFF},
 		},

--- a/soc/realtek/bee/rtl87x2g/bee_image_header.c
+++ b/soc/realtek/bee/rtl87x2g/bee_image_header.c
@@ -11,7 +11,8 @@
 
 extern void z_arm_reset(void);
 
-const T_IMG_HEADER_FORMAT img_header __attribute__((section(".image_header"))) = {
+const T_IMG_HEADER_FORMAT img_header __attribute__((section(".image_header")))
+	__attribute__((used)) = {
 	.auth = {
 		.image_mac = {
 			0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF,

--- a/soc/realtek/bee/rtl87x2j/bee_image_header.c
+++ b/soc/realtek/bee/rtl87x2j/bee_image_header.c
@@ -11,7 +11,8 @@
 
 extern void z_arm_reset(void);
 
-const T_IMG_HEADER_FORMAT img_header __attribute__((section(".image_header"))) = {
+const T_IMG_HEADER_FORMAT img_header __attribute__((section(".image_header")))
+	__attribute__((used)) = {
 	.auth = {
 		.img_string = "IMGHDR",
 		.auth_length = 0,


### PR DESCRIPTION
Problem:
- When CONFIG_LTO is enabled, the boot ROM fails to recognize the image because .image_id field in img_header is corrupted.
- LTO optimization causes the const struct img_header contents to be modified incorrectly, breaking the image header that must be placed at the beginning of the flash.

Fix:
- Add __attribute__((used)) to img_header to prevent LTO from optimizing away or modifying the structure contents.