### PR TITLE
drivers: entropy: support TRNG for rtl87x2j

### DIFF
--- a/drivers/entropy/entropy_bee.c
+++ b/drivers/entropy/entropy_bee.c
@@ -9,7 +9,7 @@
 #include <zephyr/drivers/entropy.h>
 #include <string.h>
 
-#include <utils.h>
+#include <rng_interface.h>
 
 static int entropy_bee_get_entropy(const struct device *dev, uint8_t *buffer, uint16_t length)
 {

--- a/dts/arm/realtek/bee/rtl87x2j.dtsi
+++ b/dts/arm/realtek/bee/rtl87x2j.dtsi
@@ -11,6 +11,10 @@
 #include <zephyr/dt-bindings/i2c/i2c.h>
 
 / {
+	chosen {
+		zephyr,entropy = &trng;
+	};
+
 	cpus {
 		#address-cells = <1>;
 		#size-cells = <0>;
@@ -474,6 +478,12 @@
 			interrupts = <44 0>;
 			clocks = <&cctl APB_CLK(LPQDEC)>;
 			status = "disabled";
+		};
+
+		trng: trng@40006200 {
+			compatible = "realtek,bee-trng";
+			reg = <0x40006200 0x68>;
+			status = "okay";
 		};
 
 		dma0: dma@400012c0 {


### PR DESCRIPTION
Support TRNG for rtl87x2j series SoCs.