### PR TITLE
modules: hal_realtek: osif: remove redundant timer status field

### DIFF
--- a/modules/hal_realtek/bee/osif/common/osif_zephyr_impl.c
+++ b/modules/hal_realtek/bee/osif/common/osif_zephyr_impl.c
@@ -875,7 +875,6 @@ bool os_timer_create_zephyr(void **handle_ptr, const char *timer_name, uint32_t 
 	timer->name = timer_name;
 	timer->timer_id = timer_id;
 	timer->interval_ms = interval_ms;
-	timer->status = OSIF_TIMER_NOT_ACTIVE;
 	timer->type = (uint8_t)reload;
 
 	k_timer_init(&timer->ztimer, (k_timer_expiry_t)timer_callback, NULL);
@@ -899,7 +898,6 @@ bool os_timer_start_zephyr(void **handle_ptr)
 	period = (timer->type == OSIF_TIMER_PERIODIC) ? K_MSEC(timer->interval_ms) : K_NO_WAIT;
 
 	k_timer_start(&timer->ztimer, K_MSEC(timer->interval_ms), period);
-	timer->status = OSIF_TIMER_ACTIVE;
 
 	return true;
 }
@@ -924,8 +922,6 @@ bool os_timer_restart_zephyr(void **handle_ptr, uint32_t interval_ms)
 	period = (timer->type == OSIF_TIMER_PERIODIC) ? K_MSEC(interval_ms) : K_NO_WAIT;
 	k_timer_start(&timer->ztimer, K_MSEC(interval_ms), period);
 
-	timer->status = OSIF_TIMER_ACTIVE;
-
 	return true;
 }
 
@@ -939,12 +935,7 @@ bool os_timer_stop_zephyr(void **handle_ptr)
 
 	timer = (struct osif_timer *)*handle_ptr;
 
-	if (timer->status == OSIF_TIMER_NOT_ACTIVE) {
-		return false;
-	}
-
 	k_timer_stop(&timer->ztimer);
-	timer->status = OSIF_TIMER_NOT_ACTIVE;
 	return true;
 }
 
@@ -961,7 +952,6 @@ bool os_timer_delete_zephyr(void **handle_ptr)
 	k_timer_stop(&timer->ztimer);
 
 	key = irq_lock();
-	timer->status = OSIF_TIMER_NOT_ACTIVE;
 	timer->allocated = false;
 	irq_unlock(key);
 

--- a/modules/hal_realtek/bee/osif/common/osif_zephyr_impl.h
+++ b/modules/hal_realtek/bee/osif/common/osif_zephyr_impl.h
@@ -46,7 +46,6 @@ struct osif_timer {
 	uint32_t interval_ms;
 	uint32_t timer_id;
 	uint8_t type;
-	uint8_t status;
 	const char *name;
 	bool allocated;
 };

--- a/tests/boards/realtek/bee_osif/src/osif_timer.c
+++ b/tests/boards/realtek/bee_osif/src/osif_timer.c
@@ -60,9 +60,9 @@ ZTEST(osif_timer, test_timer)
 	zassert_true(status == false, "timer1 should be inactive!");
 #endif
 
-	/* Stop the timer before start */
+	/* Stop the timer before start: os_timer_stop is idempotent, always succeeds */
 	status = os_timer_stop(&timer1);
-	zassert_true(status == false, "error while stopping non-active timer");
+	zassert_true(status == true, "error stopping non-active timer (should be idempotent)");
 
 	status = os_timer_start(&timer1);
 	zassert_true(status == true, "error starting one-shot timer");


### PR DESCRIPTION
The osif_timer struct carried a 'status' field that was only ever written to, never read back. The sole read site was a guard in os_timer_stop_zephyr that had already been commented out because it caused spurious failures: callers legitimately invoke stop as an idempotent cleanup operation, and the Zephyr k_timer_stop() API is itself idempotent.

Additionally, the field was structurally unsound for one-shot timers: there is no expiry hook to flip status back to NOT_ACTIVE when the timer fires naturally, leaving it permanently out of sync with the underlying Zephyr timer state. Both os_timer_is_timer_active_zephyr and os_timer_state_get_zephyr already bypass the field entirely and query k_timer_remaining_get() directly.

Changes:
- Remove uint8_t status from struct osif_timer
- Drop all status write sites in create/start/restart/stop/delete
- Remove the commented-out early-return guard in os_timer_stop_zephyr
- Update the osif_timer test to expect os_timer_stop to succeed when called on a not-yet-started timer (idempotent behaviour)