### PR TITLE
soc: realtek: rtl87x2j: set active mode clock source at early init

### DIFF
--- a/soc/realtek/bee/rtl87x2j/soc.c
+++ b/soc/realtek/bee/rtl87x2j/soc.c
@@ -18,6 +18,7 @@
 #include "mem_config.h"
 #include "utils.h"
 #include "sys_reset.h"
+#include "clock_manager.h"
 #ifdef CONFIG_BT
 #include "image_info.h"
 #endif
@@ -100,6 +101,8 @@ void soc_early_init_hook(void)
 
 void soc_late_init_hook(void)
 {
+	set_active_mode_clk_src();
+
 	wakeup_init();
 
 	power_manager_init();


### PR DESCRIPTION
Call set_active_mode_clk_src() in soc_early_init_hook() to configure the active mode clock source during early SoC initialization.

bt controller depends on it.