### PR TITLE
tests: secure_storage: psa: its: Fix usage of partition macros

### DIFF
--- a/tests/subsys/secure_storage/psa/its/src/main.c
+++ b/tests/subsys/secure_storage/psa/its/src/main.c
@@ -9,10 +9,10 @@
 
 /* The flash must be erased after this test suite is run for the write-once entry test to pass. */
 #if !defined(CONFIG_BUILD_WITH_TFM) && defined(CONFIG_FLASH_PAGE_LAYOUT) &&                        \
-	PARTITION_EXISTS(DT_NODELABEL(storage_partition))
+	PARTITION_EXISTS(storage_partition)
 static int erase_flash(void)
 {
-	const struct device *const fdev = PARTITION_MTD(storage_partition);
+	const struct device *const fdev = PARTITION_DEVICE(storage_partition);
 	int rc;
 
 	rc = flash_flatten(fdev, PARTITION_OFFSET(storage_partition),


### PR DESCRIPTION
The PARTITION_EXISTS macro expects a partition label, not a devicetree node derived from DT_NODELABEL.

Replace PARTITION_MTD with PARTITION_DEVICE to properly obtain a pointer to the flash controller device.


(cherry picked from commit db6503633162511b27ad8e9e847f93e59ead07fe) upstream-status: available