### PR TITLE
fix enrtopy driver compatible issue

### DIFF
--- a/drivers/entropy/entropy_bee.c
+++ b/drivers/entropy/entropy_bee.c
@@ -9,7 +9,11 @@
 #include <zephyr/drivers/entropy.h>
 #include <string.h>
 
+#if defined(CONFIG_SOC_SERIES_RTL87X2J)
 #include <rng_interface.h>
+#else
+#include <utils.h>
+#endif
 
 static int entropy_bee_get_entropy(const struct device *dev, uint8_t *buffer, uint16_t length)
 {


### PR DESCRIPTION
upstream HAL has not been merged rtl87x2j HAL which we place the platform_random API to the rng_interface.h, so use a MACRO to seperate them.

Will revert once rtl87x2j HAL merged to the upstream.