### PR TITLE
samples: tracing: increase timeslice for rtl87x2j_evb/rtl8762jth

### DIFF
--- a/samples/subsys/tracing/boards/rtl87x2j_evb_rtl8762jth.conf
+++ b/samples/subsys/tracing/boards/rtl87x2j_evb_rtl8762jth.conf
@@ -1,0 +1,8 @@
+# Increase timeslice size to avoid tracing UART output consuming the entire
+# timeslice before application code gets a chance to run. At 115200 baud,
+# after the sys timer ISR resets the timeslice, three trace hooks fire
+# sequentially (isr_exit, switched_out, switched_in), each taking ~3-4ms
+# of synchronous UART output, totalling ~9-12ms. This exceeds the default
+# 10ms timeslice, leaving no CPU time for application code to run.
+# Setting to 30ms provides sufficient headroom.
+CONFIG_TIMESLICE_SIZE=30

--- a/samples/subsys/tracing/sample.yaml
+++ b/samples/subsys/tracing/sample.yaml
@@ -10,7 +10,9 @@ common:
       - "thread_b: Hello World from (.*)!"
 tests:
   sample.tracing.user:
-    extra_args: CONF_FILE="prj_user.conf"
+    extra_args:
+      - CONF_FILE="prj_user.conf"
+      - platform:rtl87x2j_evb/rtl8762jth:EXTRA_CONF_FILE="boards/rtl87x2j_evb_rtl8762jth.conf"
     integration_platforms:
       - qemu_x86
     platform_exclude:


### PR DESCRIPTION
At 115200 baud, after the sys timer ISR resets the timeslice, three trace hooks fire sequentially (isr_exit, switched_out, switched_in), each taking ~3-4ms of synchronous UART output, totalling ~9-12ms. This exceeds the default 10ms timeslice, leaving no CPU time for application code to execute, which causes both threads to remain permanently in READY state and never reaching k_sem_take(), preventing the ping-pong Hello World output.

Add a board-specific Kconfig fragment to raise TIMESLICE_SIZE from 10ms to 30ms, providing sufficient headroom for application code to execute between scheduling events.