### PR TITLE
Fix rtl87x2j twister fail issue

### DIFF
--- a/samples/subsys/tracing/sample.yaml
+++ b/samples/subsys/tracing/sample.yaml
@@ -91,5 +91,6 @@ tests:
     extra_args:
       - CONF_FILE="prj_gpio.conf"
       - EXTRA_DTC_OVERLAY_FILE="gpio.overlay"
+      - platform:rtl87x2j_evb/rtl8762jth:EXTRA_CONF_FILE="boards/rtl87x2j_evb_rtl8762jth.conf"
     integration_platforms:
       - native_sim

--- a/tests/drivers/counter/counter_basic_api/boards/rtl87x2j_evb_rtl8762jth.overlay
+++ b/tests/drivers/counter/counter_basic_api/boards/rtl87x2j_evb_rtl8762jth.overlay
@@ -95,6 +95,6 @@
 };
 
 &rtc_counter {
-	prescaler = <1>;
+	prescaler = <10>;
 	status = "okay";
 };


### PR DESCRIPTION
- Fix tests/drivers/counter/counter_basic_api test fail issue;
- Fix samples/subsys/tracing/sample.tracing.gpio test fail issue;