### PR TITLE
tests: kernel: sched: schedule_api: replace spin_for_ms with k_busy_wait

### DIFF
--- a/tests/kernel/sched/schedule_api/src/main.c
+++ b/tests/kernel/sched/schedule_api/src/main.c
@@ -13,18 +13,6 @@ K_THREAD_STACK_ARRAY_DEFINE(tstacks, MAX_NUM_THREAD, STACK_SIZE);
 /* Not in header file intentionally, see #16760 */
 K_THREAD_STACK_DECLARE(ustack, STACK_SIZE);
 
-void spin_for_ms(int ms)
-{
-	uint32_t t32 = k_uptime_get_32();
-
-	while (k_uptime_get_32() - t32 < ms) {
-		/* In the posix arch, a busy loop takes no time, so
-		 * let's make it take some
-		 */
-		Z_SPIN_DELAY(50);
-	}
-}
-
 static void *threads_scheduling_tests_setup(void)
 {
 #ifdef CONFIG_USERSPACE

--- a/tests/kernel/sched/schedule_api/src/test_sched.h
+++ b/tests/kernel/sched/schedule_api/src/test_sched.h
@@ -24,8 +24,6 @@ struct thread_data {
 	int executed;
 };
 
-void spin_for_ms(int ticks);
-
 void test_priority_cooperative(void);
 void test_priority_preemptible(void);
 void test_priority_preemptible_wait_prio(void);

--- a/tests/kernel/sched/schedule_api/src/test_sched_timeslice_reset.c
+++ b/tests/kernel/sched/schedule_api/src/test_sched_timeslice_reset.c
@@ -106,7 +106,7 @@ static void thread_time_slice(void *p1, void *p2, void *p3)
 	/* Keep the current thread busy for more than one slice, even though,
 	 * when timeslice used up the next thread should be scheduled in.
 	 */
-	spin_for_ms(BUSY_MS);
+	k_busy_wait(BUSY_MS * USEC_PER_MSEC);
 	k_sem_give(&sema);
 }
 

--- a/tests/kernel/sched/schedule_api/src/test_slice_scheduling.c
+++ b/tests/kernel/sched/schedule_api/src/test_slice_scheduling.c
@@ -70,7 +70,7 @@ static void thread_tslice(void *p1, void *p2, void *p3)
 		 * even though, when timeslice used up the next thread
 		 * should be scheduled in.
 		 */
-		spin_for_ms(BUSY_MS);
+		k_busy_wait(BUSY_MS * USEC_PER_MSEC);
 		k_sem_give(&sema1);
 	}
 }
@@ -120,7 +120,7 @@ ZTEST(threads_scheduling, test_slice_scheduling)
 		 * even though, when timeslice used up the next thread
 		 * should be scheduled in.
 		 */
-		spin_for_ms(BUSY_MS);
+		k_busy_wait(BUSY_MS * USEC_PER_MSEC);
 
 		/* relinquish CPU and wait for each thread to complete */
 		for (int i = 0; i < NUM_THREAD; i++) {


### PR DESCRIPTION
Cherry-pick of upstream commit fde83436fb86.

spin_for_ms() polls k_uptime_get_32() in a tight loop to busy-wait for
a given number of milliseconds. This duplicates the logic of k_busy_wait()
but bypasses the architecture-specific override provided by
CONFIG_ARCH_HAS_CUSTOM_BUSY_WAIT, preventing platforms from substituting
their own correct implementation.

On rtl87x2g, the KM4 SysTick IP has a hardware bug where COUNTFLAG is
asserted one cycle early (when VAL reaches 1 rather than 0), causing
spin_for_ms() to return prematurely. We work around this via
CONFIG_ARCH_HAS_CUSTOM_BUSY_WAIT redirecting k_busy_wait() to the HAL
delay routine — but spin_for_ms() bypassed that fix entirely.

This caused 6 time-slice related test cases to fail and ultimately
a kernel panic in test_user_k_is_preempt. Tracked in BEE4RD-667.

Replace all spin_for_ms(BUSY_MS) call sites with
k_busy_wait(BUSY_MS * USEC_PER_MSEC) so that each architecture's
custom busy-wait hook is exercised, and remove the now-unused
spin_for_ms() definition and declaration.