### PR TITLE
drivers/kernel/tests: cortex_m_systick accuracy fixes and scheduler test improvements

### DIFF
--- a/drivers/timer/cortex_m_systick.c
+++ b/drivers/timer/cortex_m_systick.c
@@ -46,8 +46,12 @@ extern unsigned int z_clock_hw_cycles_per_sec;
  * set to be larger than the maximum time the interrupt might be
  * masked.  Choosing a fraction of a tick is probably a good enough
  * default, with an absolute minimum of 1k cyc.
+ *
+ * The MIN_DELAY can be overridden via device tree property "zephyr,min-timeout-cycles"
+ * for boards with low-frequency clock sources (e.g., 32kHz).
  */
-#define MIN_DELAY MAX(1024U, ((uint32_t)CYC_PER_TICK/16U))
+#define MIN_DELAY DT_PROP_OR(DT_NODELABEL(systick), zephyr_min_timeout_cycles, \
+			MAX(1024U, ((uint32_t)CYC_PER_TICK/16U)))
 
 static struct k_spinlock lock;
 

--- a/drivers/timer/cortex_m_systick.c
+++ b/drivers/timer/cortex_m_systick.c
@@ -33,10 +33,8 @@ extern unsigned int z_clock_hw_cycles_per_sec;
 #endif
 #endif
 
-/* add MAX_TICKS protection */
-#define _MAX_TICKS (int)((k_ticks_t)(COUNTER_MAX / CYC_PER_TICK) - 1)
-#define MAX_TICKS ((_MAX_TICKS > 0) ? _MAX_TICKS : 1)
-#define MAX_CYCLES (MAX_TICKS * CYC_PER_TICK)
+/* Largest delta we can program into the 24-bit LOAD register. */
+#define MAX_CYCLES ((uint32_t)COUNTER_MAX)
 
 /* Minimum cycles in the future to try to program.  Note that this is
  * NOT simply "enough cycles to get the counter read and reprogrammed
@@ -59,8 +57,10 @@ static uint32_t last_load;
 
 #ifdef CONFIG_CORTEX_M_SYSTICK_64BIT_CYCLE_COUNTER
 typedef uint64_t cycle_t;
+typedef int64_t cycle_diff_t;
 #else
 typedef uint32_t cycle_t;
+typedef int32_t cycle_diff_t;
 #endif
 
 /*
@@ -86,6 +86,14 @@ static cycle_t cycle_count;
  * dividing it by CYC_PER_TICK.
  */
 static cycle_t announced_cycles;
+
+/*
+ * Ticks reported to the kernel via sys_clock_elapsed() since the last
+ * announce. Reset in sys_clock_isr() / sys_clock_idle_exit() after an
+ * announce. Used by sys_clock_set_timeout() to compute a tick-aligned
+ * absolute deadline relative to announced_cycles.
+ */
+static uint32_t last_elapsed;
 
 /*
  * This local variable holds the amount of elapsed HW cycles due to
@@ -398,6 +406,7 @@ __attribute__((interrupt("IRQ"))) void sys_clock_isr(void)
 		dcycles = cycle_count - announced_cycles;
 		dticks = dcycles / CYC_PER_TICK;
 		announced_cycles += dticks * CYC_PER_TICK;
+		last_elapsed = 0U;
 		sys_clock_announce(dticks);
 	} else {
 		sys_clock_announce(1);
@@ -474,68 +483,107 @@ void sys_clock_set_timeout(int32_t ticks, bool idle)
 #endif /* !CONFIG_SYSTEM_TIMER_LPM_COMPANION_NONE */
 
 #if defined(CONFIG_TICKLESS_KERNEL)
-	uint32_t delay;
-	uint32_t val1, val2;
-	uint32_t last_load_ = last_load;
-
-	ticks = (ticks == K_TICKS_FOREVER) ? MAX_TICKS : ticks;
-	ticks = CLAMP(ticks - 1, 0, (int32_t)MAX_TICKS);
-
 	k_spinlock_key_t key = k_spin_lock(&lock);
 
+	/*
+	 * Sync cycle_count with current HW state, capturing any wrap that
+	 * might have occurred since the last sync point. The kernel's
+	 * preceding sys_clock_elapsed() call (or the ISR entry sync)
+	 * usually makes this redundant, but we still need to read CTRL
+	 * here to catch any wrap before writing VAL=0 destroys COUNTFLAG.
+	 *
+	 * val1 must be sampled immediately after elapsed() returns, before
+	 * the cycle_count/overflow_cyc writes below, so the window measured
+	 * by (val1 - val2) at the bottom of this function abuts the window
+	 * already accounted for by elapsed() with no gap in between. Any
+	 * instruction inserted between these two lines would be cycles that
+	 * are neither in elapsed()'s return value nor captured by the
+	 * val1/val2 drift compensation, i.e. systematically lost drift.
+	 */
 	uint32_t pending = elapsed();
-
-	val1 = SysTick->VAL;
+	uint32_t val1 = SysTick->VAL;
+	uint32_t old_load = last_load;
 
 	cycle_count += pending;
 	overflow_cyc = 0U;
 
-	uint32_t unannounced = cycle_count - announced_cycles;
+	uint32_t cycles;
 
-	if ((int32_t)unannounced < 0) {
-		/* We haven't announced for more than half the 32-bit
-		 * wrap duration, because new timeouts keep being set
-		 * before the existing one fires.  Force an announce
-		 * to avoid loss of a wrap event, making sure the
-		 * delay is at least the minimum delay possible.
+	cycle_diff_t unannounced = cycle_count - announced_cycles;
+
+	if (ticks == K_TICKS_FOREVER) {
+		/* Schedule as far out as SysTick can go in one LOAD. */
+		cycles = MAX_CYCLES;
+	} else if (unannounced < 0) {
+		/*
+		 * cycle_count has overtaken announced_cycles by more than half
+		 * the cycle_diff_t range. This is reachable when the ISR is
+		 * starved (e.g. a long-running higher-priority IRQ holds the
+		 * CPU) while sys_clock_set_timeout() keeps growing cycle_count
+		 * call after call. Force a near-immediate fire so the ISR can
+		 * drain the backlog before the gap wraps past the unsigned
+		 * range and we start losing cycles permanently. In the 64-bit
+		 * cycle_t configuration this branch is statically unreachable.
 		 */
-		last_load = MIN_DELAY;
+		cycles = MIN_DELAY;
 	} else {
-		/* Desired delay in the future */
-		delay = ticks * CYC_PER_TICK;
+		/*
+		 * Compute the number of cycles from 'now' to a tick-aligned
+		 * deadline measured from the last announce. last_elapsed is
+		 * the tick count most recently reported to the kernel via
+		 * sys_clock_elapsed(); the kernel's 'ticks' argument is
+		 * measured from that report. 64-bit math absorbs arbitrarily
+		 * large 'ticks' without overflowing the intermediate product.
+		 */
+		int64_t want = ((uint64_t)last_elapsed + ticks) * CYC_PER_TICK;
+		int64_t delta_64 = want - unannounced;
 
-		/* Round delay up to next tick boundary */
-		delay += unannounced;
-		delay = DIV_ROUND_UP(delay, CYC_PER_TICK) * CYC_PER_TICK;
-		delay -= unannounced;
-		delay = MAX(delay, MIN_DELAY);
-		if (delay > MAX_CYCLES) {
-			last_load = MAX_CYCLES;
-		} else {
-			last_load = delay;
-		}
+		/*
+		 * Clamp to [MIN_DELAY, MAX_CYCLES] so the programmed LOAD is
+		 * within SysTick's 24-bit range and leaves enough cycles to
+		 * reliably service the next ISR. A past-deadline request
+		 * (delta_64 <= 0) is pulled up to MIN_DELAY to fire ASAP.
+		 */
+		cycles = CLAMP(delta_64, (int64_t)MIN_DELAY, (int64_t)MAX_CYCLES);
 	}
-
-	val2 = SysTick->VAL;
-
-	SysTick->LOAD = last_load - 1;
-	SysTick->VAL = 0; /* resets timer to last_load */
 
 	/*
-	 * Add elapsed cycles while computing the new load to cycle_count.
+	 * val2 must be sampled while the OLD LOAD is still the reload source:
+	 * if a wrap happened between SysTick->LOAD being reprogrammed and the
+	 * val2 read, VAL would reload from the NEW LOAD and the drift-comp
+	 * formula below (which uses old_load for the wrap case) would be
+	 * wrong. Updating last_load (a software shadow) is HW-inert and safe
+	 * to do before val2.
 	 *
-	 * Note that comparing val1 and val2 is normally not good enough to
-	 * guess if the counter wrapped during this interval. Indeed if val1 is
-	 * close to LOAD, then there are little chances to catch val2 between
-	 * val1 and LOAD after a wrap. COUNTFLAG should be checked in addition.
-	 * But since the load computation is faster than MIN_DELAY, then we
-	 * don't need to worry about this case.
+	 * COUNTFLAG is not checked here: the caller guarantees this runs
+	 * faster than MIN_DELAY cycles, so a wrap cannot be missed.
 	 */
+	last_load = cycles;
+
+	uint32_t val2 = SysTick->VAL;
+
+	SysTick->LOAD = cycles - 1U;
+	SysTick->VAL = 0U;	/* resets counter, clears COUNTFLAG */
+
+	/*
+	 * Clear any pending SysTick exception from the old schedule.
+	 * Writing VAL=0 clears COUNTFLAG in CTRL but not ICSR.PENDSTSET,
+	 * so without this a wrap that fired just before the reprogram
+	 * would still trigger the ISR once interrupts are re-enabled.
+	 * On Armv8-M, preserve STTNS (R/W) while writing the W1C bit.
+	 */
+#ifdef SCB_ICSR_STTNS_Msk
+	SCB->ICSR = (SCB->ICSR & SCB_ICSR_STTNS_Msk) | SCB_ICSR_PENDSTCLR_Msk;
+#else
+	SCB->ICSR = SCB_ICSR_PENDSTCLR_Msk;
+#endif
+
 	if (val1 < val2) {
-		cycle_count += (val1 + (last_load_ - val2));
+		cycle_count += val1 + (old_load - val2);
 	} else {
-		cycle_count += (val1 - val2);
+		cycle_count += val1 - val2;
 	}
+
 	k_spin_unlock(&lock, key);
 #endif
 }
@@ -549,9 +597,11 @@ uint32_t sys_clock_elapsed(void)
 	k_spinlock_key_t key = k_spin_lock(&lock);
 	uint32_t unannounced = cycle_count - announced_cycles;
 	uint32_t cyc = elapsed() + unannounced;
+	uint32_t dticks = cyc / CYC_PER_TICK;
 
+	last_elapsed = dticks;
 	k_spin_unlock(&lock, key);
-	return cyc / CYC_PER_TICK;
+	return dticks;
 }
 
 uint32_t sys_clock_cycle_get_32(void)
@@ -626,6 +676,7 @@ void sys_clock_idle_exit(void)
 		dcycles = cycle_count + elapsed() - announced_cycles;
 		dticks = dcycles / CYC_PER_TICK;
 		announced_cycles += dticks * CYC_PER_TICK;
+		last_elapsed = 0U;
 		sys_clock_announce(dticks);
 
 		/* We've already performed all needed operations */

--- a/drivers/timer/cortex_m_systick.c
+++ b/drivers/timer/cortex_m_systick.c
@@ -511,10 +511,7 @@ void sys_clock_set_timeout(uint32_t ticks, bool idle)
 
 	cycle_diff_t unannounced = cycle_count - announced_cycles;
 
-	if (ticks == K_TICKS_FOREVER) {
-		/* Schedule as far out as SysTick can go in one LOAD. */
-		cycles = MAX_CYCLES;
-	} else if (unannounced < 0) {
+	if (unannounced < 0) {
 		/*
 		 * cycle_count has overtaken announced_cycles by more than half
 		 * the cycle_diff_t range. This is reachable when the ISR is

--- a/drivers/timer/cortex_m_systick.c
+++ b/drivers/timer/cortex_m_systick.c
@@ -36,24 +36,69 @@ extern unsigned int z_clock_hw_cycles_per_sec;
 /* Largest delta we can program into the 24-bit LOAD register. */
 #define MAX_CYCLES ((uint32_t)COUNTER_MAX)
 
-/* Minimum cycles in the future to try to program.  Note that this is
- * NOT simply "enough cycles to get the counter read and reprogrammed
- * reliably" -- it becomes the minimum value of the LOAD register, and
- * thus reflects how much time we can reliably see expire between
- * calls to elapsed() to read the COUNTFLAG bit.  So it needs to be
- * set to be larger than the maximum time the interrupt might be
- * masked.  Choosing a fraction of a tick is probably a good enough
- * default, with an absolute minimum of 1k cyc.
+/* Minimum reload the driver will program, i.e. the closest-in timeout it can
+ * schedule. Two floors apply.
  *
- * The MIN_DELAY can be overridden via device tree property "zephyr,min-timeout-cycles"
- * for boards with low-frequency clock sources (e.g., 32kHz).
+ * Hardware: LOAD is programmed as (cycles - 1), and a LOAD of zero stops the
+ * counter (it reloads to zero and never makes another 1->0 transition, so no
+ * further interrupt), so the smallest usable value is two cycles (LOAD 1).
+ *
+ * Masking: it must also exceed the longest time the SysTick interrupt can stay
+ * masked. elapsed() reconstructs the current cycle count assuming at most one
+ * wrap of the counter has happened since it last ran; it cannot tell one wrap
+ * from several. With a tiny LOAD the counter wraps every few cycles, so if
+ * interrupts are then held off longer than that LOAD (a long critical section,
+ * or a higher-priority ISR that runs for a while) the counter wraps two or
+ * more times before the SysTick ISR can account for it. Each unaccounted wrap
+ * silently drops a full LOAD's worth of cycles: the software clock falls
+ * permanently behind real time and every pending timeout fires late by that
+ * much. A floor above the worst-case masking window guarantees at most one
+ * wrap between reads, which elapsed() does handle.
+ *
+ * That is a wall-clock budget, so express it as a fixed time converted to
+ * cycles at the actual frequency (k_us_to_cyc_ceil32() follows the runtime
+ * rate where the timer reports it), computed at init. A fixed cycle count is
+ * meaningless across clock rates: the old 1024-cycle floor is ~10 us at
+ * 100 MHz but ~31 ms (31 ticks!) on a 32 kHz SysTick. The tick rate is
+ * deliberately not involved; if the resulting value exceeds one tick on some
+ * clock, sub-tick timeouts are simply unavailable there.
+ *
+ * Keep it as small as correctness allows, not as large as a tick would
+ * permit: this is a floor for safe rescheduling, not a jitter control.
+ * Inflating it does trim the short-period tail, but it eats sub-tick headroom,
+ * and as it approaches CYC_PER_TICK the driver can no longer place a timeout
+ * inside the current tick, so the small per-ISR surplus is carried over and
+ * two ticks get announced at once (a double expiry). 10 us is under a cycle at
+ * 32 kHz, where the two-cycle hardware floor takes over; either way it stays
+ * far below CYC_PER_TICK.
+ *
+ * A device tree "zephyr,min-timeout-cycles" property still overrides the
+ * budget, subject to the same two-cycle hardware floor.
  */
-#define MIN_DELAY DT_PROP_OR(DT_NODELABEL(systick), zephyr_min_timeout_cycles, \
-			MAX(1024U, ((uint32_t)CYC_PER_TICK/16U)))
+#define SYSTICK_MIN_DELAY_US 10U
+
+static inline uint32_t systick_min_delay(void)
+{
+	uint32_t override_cyc =
+		DT_PROP_OR(DT_NODELABEL(systick), zephyr_min_timeout_cycles, 0U);
+	uint32_t cyc = (override_cyc != 0U) ? override_cyc
+					    : k_us_to_cyc_ceil32(SYSTICK_MIN_DELAY_US);
+
+	/* Floor at two cycles: LOAD is programmed as (cycles - 1) and a LOAD
+	 * of zero stops the counter. This is the binding floor on a slow clock
+	 * (e.g. 32 kHz, where the 10 us budget rounds below it).
+	 */
+	return MAX(2U, cyc);
+}
 
 static struct k_spinlock lock;
 
 static uint32_t last_load;
+
+/* Minimum LOAD value; derived from the cycle rate in sys_clock_driver_init()
+ * (and refreshed on a runtime frequency change). See systick_min_delay().
+ */
+static uint32_t min_delay;
 
 #ifdef CONFIG_CORTEX_M_SYSTICK_64BIT_CYCLE_COUNTER
 typedef uint64_t cycle_t;
@@ -121,6 +166,10 @@ void z_sys_clock_hw_cycles_per_sec_update(uint32_t new_hz)
 
 	/* Publish the new frequency. */
 	z_clock_hw_cycles_per_sec = new_hz;
+
+	/* The floor is a wall-clock budget, so re-derive it at the new rate. */
+	min_delay = systick_min_delay();
+
 	uint32_t load_old = last_load;
 
 	if (load_old != TIMER_STOPPED) {
@@ -149,7 +198,7 @@ void z_sys_clock_hw_cycles_per_sec_update(uint32_t new_hz)
 			new_load = CYC_PER_TICK;
 		}
 
-		new_load = MAX(new_load, MIN_DELAY);
+		new_load = MAX(new_load, min_delay);
 		if (new_load > COUNTER_MAX) {
 			new_load = COUNTER_MAX;
 		}
@@ -522,7 +571,7 @@ void sys_clock_set_timeout(uint32_t ticks, bool idle)
 		 * range and we start losing cycles permanently. In the 64-bit
 		 * cycle_t configuration this branch is statically unreachable.
 		 */
-		cycles = MIN_DELAY;
+		cycles = min_delay;
 	} else {
 		/*
 		 * Compute the number of cycles from 'now' to a tick-aligned
@@ -541,7 +590,7 @@ void sys_clock_set_timeout(uint32_t ticks, bool idle)
 		 * reliably service the next ISR. A past-deadline request
 		 * (delta_64 <= 0) is pulled up to MIN_DELAY to fire ASAP.
 		 */
-		cycles = CLAMP(delta_64, (int64_t)MIN_DELAY, (int64_t)MAX_CYCLES);
+		cycles = CLAMP(delta_64, (int64_t)min_delay, (int64_t)MAX_CYCLES);
 	}
 
 	/*
@@ -710,6 +759,7 @@ static int sys_clock_driver_init(void)
 {
 
 	NVIC_SetPriority(SysTick_IRQn, _IRQ_PRIO_OFFSET);
+	min_delay = systick_min_delay();
 	last_load = CYC_PER_TICK;
 	overflow_cyc = 0U;
 	SysTick->LOAD = last_load - 1;

--- a/drivers/timer/cortex_m_systick.c
+++ b/drivers/timer/cortex_m_systick.c
@@ -422,7 +422,7 @@ __attribute__((interrupt("IRQ"))) void sys_clock_isr(void)
 }
 ARCH_ISR_DIAG_ON
 
-void sys_clock_set_timeout(int32_t ticks, bool idle)
+void sys_clock_set_timeout(uint32_t ticks, bool idle)
 {
 	/* Fast CPUs and a 24 bit counter mean that even idle systems
 	 * need to wake up multiple times per second.  If the kernel

--- a/drivers/timer/sys_clock_init.c
+++ b/drivers/timer/sys_clock_init.c
@@ -18,7 +18,7 @@
 
 /* Weak-linked noop defaults for optional driver interfaces*/
 
-void __weak sys_clock_set_timeout(int32_t ticks, bool idle)
+void __weak sys_clock_set_timeout(uint32_t ticks, bool idle)
 {
 }
 

--- a/dts/arm/realtek/bee/rtl8752h.dtsi
+++ b/dts/arm/realtek/bee/rtl8752h.dtsi
@@ -444,4 +444,6 @@
 
 &systick {
 	external-clock-source;
+	/* zephyr,min-timeout-cycles: 32 cycles @ 32kHz = 1ms (1 tick) */
+	zephyr,min-timeout-cycles = <32>;
 };

--- a/dts/arm/realtek/bee/rtl8752h.dtsi
+++ b/dts/arm/realtek/bee/rtl8752h.dtsi
@@ -444,6 +444,4 @@
 
 &systick {
 	external-clock-source;
-	/* zephyr,min-timeout-cycles: 32 cycles @ 32kHz = 1ms (1 tick) */
-	zephyr,min-timeout-cycles = <32>;
 };

--- a/dts/arm/realtek/bee/rtl87x2g.dtsi
+++ b/dts/arm/realtek/bee/rtl87x2g.dtsi
@@ -587,6 +587,4 @@
 
 &systick {
 	external-clock-source;
-	/* zephyr,min-timeout-cycles: 32 cycles @ 32kHz = 1ms (1 tick) */
-	zephyr,min-timeout-cycles = <32>;
 };

--- a/dts/arm/realtek/bee/rtl87x2g.dtsi
+++ b/dts/arm/realtek/bee/rtl87x2g.dtsi
@@ -587,4 +587,6 @@
 
 &systick {
 	external-clock-source;
+	/* zephyr,min-timeout-cycles: 32 cycles @ 32kHz = 1ms (1 tick) */
+	zephyr,min-timeout-cycles = <32>;
 };

--- a/dts/bindings/timer/cortex-m-systick.yaml
+++ b/dts/bindings/timer/cortex-m-systick.yaml
@@ -15,3 +15,25 @@ properties:
       SysTick Control and Status Register (CSR) selects the clock source.
       If this property is present, the external reference clock is selected.
       If absent, the processor/core clock is selected.
+
+  zephyr,min-timeout-cycles:
+    type: int
+    description: |
+      Minimum SysTick timeout, in SysTick cycles. This is the smallest value the
+      SysTick driver will program into the timer LOAD register. It determines the
+      kernel's minimum available timing granularity (resolution) in conjunction
+      with the clock frequency (CONFIG_SYS_CLOCK_HW_CYCLES_PER_SEC).
+
+      When specified, the minimum timing granularity is
+      (<value> cycles / CONFIG_SYS_CLOCK_HW_CYCLES_PER_SEC) seconds.
+      Otherwise, the default is MAX(1024, CYC_PER_TICK / 16) cycles, where
+      CYC_PER_TICK = CONFIG_SYS_CLOCK_HW_CYCLES_PER_SEC /
+      CONFIG_SYS_CLOCK_TICKS_PER_SEC.
+
+      For example, if CONFIG_SYS_CLOCK_HW_CYCLES_PER_SEC=32768 and
+      CONFIG_SYS_CLOCK_TICKS_PER_SEC=1000, CYC_PER_TICK equals 32 cycles.
+      In this case, the default MIN_DELAY is MAX(1024, 32/16) = 1024 cycles,
+      which corresponds to ~31.25 ms. This might be too coarse for many use
+      cases. Setting this property to 32 (zephyr,min-timeout-cycles = <32>;)
+      results in a minimum timing granularity of (32 / 32768) seconds (~1 ms)
+      instead.

--- a/include/zephyr/drivers/timer/system_timer.h
+++ b/include/zephyr/drivers/timer/system_timer.h
@@ -120,9 +120,8 @@ static inline void sys_clock_unlock(k_spinlock_key_t key)
  * is that one tick announcement should occur within one tick BEFORE
  * the specified expiration (that is, passing ticks==1 means "announce
  * the next tick", this convention was chosen to match legacy usage).
- * Similarly a ticks value of zero (or even negative) is legal and
- * treated identically: it simply indicates the kernel would like the
- * next tick announcement as soon as possible.
+ * Similarly a ticks value of zero is legal: it simply indicates the
+ * kernel would like the next tick announcement as soon as possible.
  *
  * Note that ticks can also be passed the special value K_TICKS_FOREVER,
  * indicating that no future timer interrupts are expected or required
@@ -154,7 +153,7 @@ static inline void sys_clock_unlock(k_spinlock_key_t key)
  * @param idle Hint to the driver that the system is about to enter
  *        the idle state immediately after setting the timeout
  */
-void sys_clock_set_timeout(int32_t ticks, bool idle);
+void sys_clock_set_timeout(uint32_t ticks, bool idle);
 
 /**
  * @brief Timer idle exit notification
@@ -190,7 +189,7 @@ void sys_clock_idle_exit(void);
  * @param ticks Elapsed time, in ticks
  * @param key Lock key obtained from sys_clock_lock().
  */
-void sys_clock_announce_locked(int32_t ticks, k_spinlock_key_t key);
+void sys_clock_announce_locked(uint32_t ticks, k_spinlock_key_t key);
 
 /**
  * @brief Announce time progress to the kernel (legacy wrapper)
@@ -202,7 +201,7 @@ void sys_clock_announce_locked(int32_t ticks, k_spinlock_key_t key);
  *
  * @param ticks Elapsed time, in ticks
  */
-static inline void sys_clock_announce(int32_t ticks)
+static inline void sys_clock_announce(uint32_t ticks)
 {
 	sys_clock_announce_locked(ticks, sys_clock_lock());
 }

--- a/kernel/timeout.c
+++ b/kernel/timeout.c
@@ -108,7 +108,23 @@ k_ticks_t z_add_timeout(struct _timeout *to, _timeout_func_t fn, k_timeout_t tim
 		if (Z_IS_TIMEOUT_RELATIVE(timeout)) {
 			ticks_elapsed = elapsed();
 			has_elapsed = true;
-			to->dticks = timeout.ticks + 1 + ticks_elapsed;
+			/*
+			 * In the general case, "now" may be anywhere within
+			 * the current tick. Rounding up by one tick guarantees
+			 * "at least N ticks" semantics -- otherwise a request
+			 * made partway through a tick would fire on the next
+			 * tick edge, yielding less than N full ticks.
+			 *
+			 * The one moment we know we are at (or very close to)
+			 * a tick edge is while processing timeouts inside
+			 * sys_clock_announce_locked(), flagged by
+			 * announce_remaining != 0. Periodic timers rely on
+			 * this when rescheduling themselves from the timer
+			 * ISR: the round-up would otherwise accumulate and
+			 * make every period one tick late.
+			 */
+			to->dticks = timeout.ticks + ticks_elapsed +
+				     ((announce_remaining == 0) ? 1 : 0);
 			ticks = curr_tick + to->dticks;
 		} else {
 			k_ticks_t dticks = Z_TICK_ABS(timeout.ticks) - curr_tick;

--- a/kernel/timeout.c
+++ b/kernel/timeout.c
@@ -24,7 +24,7 @@ static sys_dlist_t timeout_list = SYS_DLIST_STATIC_INIT(&timeout_list);
 static struct k_spinlock timeout_lock;
 
 /* Ticks left to process in the currently-executing sys_clock_announce() */
-static int announce_remaining;
+static uint32_t announce_remaining;
 
 static struct _timeout *first(void)
 {
@@ -49,7 +49,7 @@ static void remove_timeout(struct _timeout *t)
 	sys_dlist_remove(&t->node);
 }
 
-static int32_t elapsed(void)
+static uint32_t elapsed(void)
 {
 	/* While sys_clock_announce() is executing, new relative timeouts will be
 	 * scheduled relatively to the currently firing timeout's original tick
@@ -102,7 +102,7 @@ k_ticks_t z_add_timeout(struct _timeout *to, _timeout_func_t fn, k_timeout_t tim
 
 	K_SPINLOCK(&timeout_lock) {
 		struct _timeout *t;
-		int32_t ticks_elapsed;
+		uint32_t ticks_elapsed;
 		bool has_elapsed = false;
 
 		if (Z_IS_TIMEOUT_RELATIVE(timeout)) {
@@ -220,7 +220,7 @@ int32_t z_get_next_timeout_expiry(void)
 	return ret;
 }
 
-void sys_clock_announce_locked(int32_t ticks, k_spinlock_key_t key)
+void sys_clock_announce_locked(uint32_t ticks, k_spinlock_key_t key)
 {
 	/* We release the lock around the callbacks below, so on SMP
 	 * systems someone might be already running the loop.  Don't

--- a/kernel/timer.c
+++ b/kernel/timer.c
@@ -87,9 +87,6 @@ void z_timer_expiration_handler(struct _timeout *t)
 	    !K_TIMEOUT_EQ(timer->period, K_FOREVER)) {
 		k_timeout_t next = timer->period;
 
-		/* see note about z_add_timeout() in z_impl_k_timer_start() */
-		next.ticks = max(next.ticks - 1, 0);
-
 #ifdef CONFIG_TIMEOUT_64BIT
 		/* Exploit the fact that uptime during a kernel
 		 * timeout handler reflects the time of the scheduled
@@ -98,11 +95,8 @@ void z_timer_expiration_handler(struct _timeout *t)
 		 * delayed for any reason, we still end up calculating
 		 * the next expiration as a regular stride from where
 		 * we "should" have run.  Requires absolute timeouts.
-		 * (Note offset by one: we're nominally at the
-		 * beginning of a tick, so need to defeat the "round
-		 * down" behavior on timeout addition).
 		 */
-		next = K_TIMEOUT_ABS_TICKS(k_uptime_ticks() + 1 + next.ticks);
+		next = K_TIMEOUT_ABS_TICKS(k_uptime_ticks() + next.ticks);
 #endif /* CONFIG_TIMEOUT_64BIT */
 		z_add_timeout(&timer->timeout, z_timer_expiration_handler,
 			      next);

--- a/kernel/timeslicing.c
+++ b/kernel/timeslicing.c
@@ -81,7 +81,7 @@ void z_reset_time_slice(struct k_thread *thread)
 	slice_expired[cpu] = false;
 	if (slice_size != 0) {
 		z_add_timeout(&slice_timeouts[cpu], slice_timeout,
-			      K_TICKS(slice_size - 1));
+			      K_TICKS(slice_size));
 	}
 }
 

--- a/kernel/timeslicing.c
+++ b/kernel/timeslicing.c
@@ -78,11 +78,18 @@ void z_reset_time_slice(struct k_thread *thread)
 	int slice_size = z_time_slice_size(thread);
 
 	z_abort_timeout(&slice_timeouts[cpu]);
-	slice_expired[cpu] = false;
 	if (slice_size != 0) {
+		/* When invoked because the slicer just fired (this CPU or
+		 * via IPI from another), we're at a tick edge but past the
+		 * announce window, so subtract 1 to cancel z_add_timeout()'s
+		 * "+1" round-up and land at exactly slice_size ticks.
+		 */
+		int delay = slice_expired[cpu] ? slice_size - 1 : slice_size;
+
 		z_add_timeout(&slice_timeouts[cpu], slice_timeout,
-			      K_TICKS(slice_size));
+			      K_TICKS(delay));
 	}
+	slice_expired[cpu] = false;
 }
 
 static ALWAYS_INLINE bool thread_defines_time_slice_size(struct k_thread *thread)
@@ -154,8 +161,25 @@ void z_time_slice(void)
 #endif
 		if (!z_is_thread_prevented_from_running(curr)) {
 			move_current_to_end_of_prio_q();
+			/* If the rotation kept curr at the front (no other
+			 * runnable thread of equal-or-higher priority is
+			 * waiting), no swap will happen and we must rearm
+			 * here. Otherwise the dispatch path will rearm for
+			 * the new thread with slice_expired still set,
+			 * picking up the tick-aligned delay.
+			 */
+#ifdef CONFIG_SMP
+			struct k_thread *next = runq_best();
+
+			if (next == NULL || z_is_idle_thread_object(next)) {
+				z_reset_time_slice(curr);
+			}
+#else
+			if (_kernel.ready_q.cache == curr) {
+				z_reset_time_slice(curr);
+			}
+#endif
 		}
-		z_reset_time_slice(curr);
 	}
 	k_spin_unlock(&_sched_spinlock, key);
 }

--- a/tests/kernel/sched/deadline/src/main.c
+++ b/tests/kernel/sched/deadline/src/main.c
@@ -53,6 +53,27 @@ void worker(void *p1, void *p2, void *p3)
 	}
 }
 
+/**
+ * @brief Verify EDF threads run in earliest-deadline-first order.
+ *
+ * @details
+ * At equal priority the scheduler must order runnable threads by their deadline
+ * (set via k_thread_deadline_set()), running the earliest deadline first.
+ * Several equal-priority threads are given random deadlines and must execute in
+ * ascending-deadline order.
+ *
+ * Test steps:
+ * - Create NUM_THREADS equal-priority threads, each recording its run order.
+ * - Assign each a random deadline, then sleep to let them run.
+ * - Verify their execution order matches ascending deadline order.
+ *
+ * Expected result:
+ * - Threads execute earliest-deadline-first.
+ *
+ * @ingroup tests_kernel_sched
+ *
+ * @see k_thread_deadline_set()
+ */
 ZTEST(suite_deadline, test_deadline)
 {
 	int i;
@@ -134,6 +155,26 @@ void yield_worker(void *p1, void *p2, void *p3)
 	CODE_UNREACHABLE;
 }
 
+/**
+ * @brief Verify k_yield() rotates among equal deadline/priority threads.
+ *
+ * @details
+ * Threads at the same priority and deadline (0) must each get to run when they
+ * cooperatively yield. Each worker increments a counter and yields; all must
+ * have run by the time the test wakes.
+ *
+ * Test steps:
+ * - Create NUM_THREADS equal-priority/deadline threads that bump a counter and
+ *   k_yield().
+ * - Sleep and verify all threads ran.
+ *
+ * Expected result:
+ * - Every thread runs, confirming yield rotates among equal peers.
+ *
+ * @ingroup tests_kernel_sched
+ *
+ * @see k_yield()
+ */
 ZTEST(suite_deadline, test_yield)
 {
 	/* Test that yield works across threads with the
@@ -178,13 +219,26 @@ void unqueue_worker(void *p1, void *p2, void *p3)
 }
 
 /**
- * @brief Validate the behavior of deadline_set when the thread is not queued
+ * @brief Verify k_thread_deadline_set() does not wake a not-yet-started thread.
  *
- * @details Create a bunch of threads with scheduling delay which make the
- * thread in unqueued state. The k_thread_deadline_set() call should not make
- * these threads run before there delay time pass.
+ * @details
+ * Setting a deadline on a thread that is still in its start delay (unqueued)
+ * must not make it run before its delay elapses. Threads are created with a
+ * start delay, given deadlines while unqueued, and must stay dormant until the
+ * delay passes.
  *
- * @ingroup kernel_sched_tests
+ * Test steps:
+ * - Create NUM_THREADS threads with a start delay (unqueued).
+ * - Set a random deadline on each and sleep less than the delay; none must run.
+ * - Sleep past the delay and confirm all threads then run.
+ *
+ * Expected result:
+ * - Deadline-set does not start an unqueued thread early; threads run only after
+ *   their start delay.
+ *
+ * @ingroup tests_kernel_sched
+ *
+ * @see k_thread_deadline_set()
  */
 ZTEST(suite_deadline, test_unqueued)
 {
@@ -270,6 +324,29 @@ static void thread_offload(void (*f)(const void *p), const void *param)
 	f(param);
 }
 
+/**
+ * @brief Verify a deadline change takes effect only on k_reschedule().
+ *
+ * @details
+ * Changing a thread's deadline does not by itself trigger a context switch; an
+ * explicit k_reschedule() must re-evaluate the ready queue and switch to the now
+ * earliest-deadline thread. The test orchestrates two EDF helpers and checks the
+ * expected thread is selected only after k_reschedule() (exercised via a direct
+ * call and, on non-SMP, via irq_offload). Built for single-CPU configs only.
+ *
+ * Test steps:
+ * - Create two EDF helper threads with different deadlines.
+ * - Confirm changing a deadline alone causes no switch.
+ * - Invoke k_reschedule() and confirm the expected thread is then selected.
+ *
+ * Expected result:
+ * - The scheduler switches to the earliest-deadline thread only on reschedule.
+ *
+ * @ingroup tests_kernel_sched
+ *
+ * @see k_reschedule()
+ * @see k_thread_deadline_set()
+ */
 ZTEST(suite_deadline, test_thread_reschedule)
 {
 	k_thread_create(&worker_threads[0], worker_stacks[0], STACK_SIZE,

--- a/tests/kernel/sched/metairq/src/main.c
+++ b/tests/kernel/sched/metairq/src/main.c
@@ -189,6 +189,29 @@ void join_participant_threads(void)
 	JOIN_PARTICIPANT_THREAD(coop_thread2_id);
 }
 
+/**
+ * @brief Verify a meta-IRQ returns to the cooperative thread it preempted.
+ *
+ * @details
+ * A meta-IRQ thread may preempt a running cooperative thread, but on completion
+ * the scheduler must resume that same cooperative thread rather than switching to
+ * another ready cooperative thread. The meta-IRQ unblocks a long-running
+ * low-priority coop thread, then unblocks a higher-priority coop thread before
+ * the first finishes; execution must continue in the low-priority thread and run
+ * the high-priority one only afterwards.
+ *
+ * Test steps:
+ * - Start a meta-IRQ thread and two cooperative threads (low and high priority).
+ * - The meta-IRQ unblocks the low-priority coop thread, sleeps, then unblocks the
+ *   high-priority coop thread mid-run.
+ * - Observe the order in which the coop threads complete.
+ *
+ * Expected result:
+ * - The preempted low-priority coop thread resumes first; the high-priority coop
+ *   thread runs after it, confirming the meta-IRQ returns to its preemptee.
+ *
+ * @ingroup tests_kernel_sched
+ */
 ZTEST(suite_preempt_metairq, test_preempt_metairq)
 {
 	create_participant_threads();

--- a/tests/kernel/sched/preempt/src/main.c
+++ b/tests/kernel/sched/preempt/src/main.c
@@ -296,9 +296,31 @@ void worker(void *p1, void *p2, void *p3)
 }
 
 /**
- * @brief Test preemption
+ * @brief Verify wakeups preempt the running thread per the documented rules.
  *
- * @ingroup kernel_sched_tests
+ * @details
+ * Exhaustively checks which thread runs next when a thread is woken, across all
+ * priority classes (cooperative, preemptible, meta-IRQ). Threads in each class
+ * sleep; a low-priority manager wakes one, which wakes another, and the test
+ * validates the next-to-run thread matches the documented preemption rules. The
+ * check is repeated for all four combinations of holding/not holding the
+ * scheduler lock and for synchronous versus interrupt-context (offloaded) wakes.
+ * Single-CPU only.
+ *
+ * Test steps:
+ * - Create paired threads at cooperative, preemptible and meta-IRQ priorities,
+ *   all sleeping, plus a manager thread.
+ * - For each scenario, wake a thread that arranges to wake a target thread.
+ * - Validate the actually-scheduled thread against the expected one.
+ *
+ * Expected result:
+ * - The next thread to run always matches the documented preemption rules for
+ *   every class/lock/context combination.
+ *
+ * @ingroup tests_kernel_sched
+ *
+ * @see k_wakeup()
+ * @see k_sched_lock()
  */
 ZTEST(suite_preempt, test_preempt)
 {

--- a/tests/kernel/sched/schedule_api/src/main.c
+++ b/tests/kernel/sched/schedule_api/src/main.c
@@ -13,18 +13,6 @@ K_THREAD_STACK_ARRAY_DEFINE(tstacks, MAX_NUM_THREAD, STACK_SIZE);
 /* Not in header file intentionally, see #16760 */
 K_THREAD_STACK_DECLARE(ustack, STACK_SIZE);
 
-void spin_for_ms(int ms)
-{
-	uint32_t t32 = k_uptime_get_32();
-
-	while (k_uptime_get_32() - t32 < ms) {
-		/* In the posix arch, a busy loop takes no time, so
-		 * let's make it take some
-		 */
-		Z_SPIN_DELAY(50);
-	}
-}
-
 static void *threads_scheduling_tests_setup(void)
 {
 #ifdef CONFIG_USERSPACE

--- a/tests/kernel/sched/schedule_api/src/main.c
+++ b/tests/kernel/sched/schedule_api/src/main.c
@@ -38,7 +38,7 @@ static void *threads_scheduling_tests_setup(void)
 /**
  * @brief Test scheduling
  *
- * @defgroup kernel_sched_tests Scheduling Tests
+ * @defgroup tests_kernel_sched Scheduling tests
  *
  * @ingroup all_tests
  *

--- a/tests/kernel/sched/schedule_api/src/test_priority_scheduling.c
+++ b/tests/kernel/sched/schedule_api/src/test_priority_scheduling.c
@@ -63,7 +63,7 @@ static void thread_tslice(void *p1, void *p2, void *p3)
  * current thread is also made preemptive. Check how the threads get chance to
  * execute based on their priorities
  *
- * @ingroup kernel_sched_tests
+ * @ingroup tests_kernel_sched
  */
 ZTEST(threads_scheduling, test_priority_scheduling)
 {

--- a/tests/kernel/sched/schedule_api/src/test_sched.h
+++ b/tests/kernel/sched/schedule_api/src/test_sched.h
@@ -56,4 +56,16 @@ void test_k_thread_priority_set_upgrade(void);
 void test_k_wakeup_init_null(void);
 void test_slice_perthread(void);
 
+/* Tick-domain uptime delta: returns ticks since *reftime, updates
+ * *reftime. Delta fits in uint32_t for slice-scale measurements.
+ */
+static inline uint32_t ticks_delta(uint64_t *reftime)
+{
+	uint64_t now = k_uptime_ticks();
+	uint32_t delta = now - *reftime;
+
+	*reftime = now;
+	return delta;
+}
+
 #endif /* __TEST_SCHED_H__ */

--- a/tests/kernel/sched/schedule_api/src/test_sched.h
+++ b/tests/kernel/sched/schedule_api/src/test_sched.h
@@ -24,8 +24,6 @@ struct thread_data {
 	int executed;
 };
 
-void spin_for_ms(int ticks);
-
 void test_priority_cooperative(void);
 void test_priority_preemptible(void);
 void test_priority_preemptible_wait_prio(void);

--- a/tests/kernel/sched/schedule_api/src/test_sched_is_preempt_thread.c
+++ b/tests/kernel/sched/schedule_api/src/test_sched_is_preempt_thread.c
@@ -63,7 +63,7 @@ static void tcoop_ctx(void *p1, void *p2, void *p3)
  *
  * @see k_is_preempt_thread()
  *
- * @ingroup kernel_sched_tests
+ * @ingroup tests_kernel_sched
  */
 ZTEST(threads_scheduling, test_sched_is_preempt_thread)
 {

--- a/tests/kernel/sched/schedule_api/src/test_sched_priority.c
+++ b/tests/kernel/sched/schedule_api/src/test_sched_priority.c
@@ -42,7 +42,7 @@ static void thread_entry_prio(void *p1, void *p2, void *p3)
  * priority thread will not preempt the lower priority cooperative
  * thread.
  *
- * @ingroup kernel_sched_tests
+ * @ingroup tests_kernel_sched
  */
 ZTEST(threads_scheduling, test_priority_cooperative)
 {
@@ -78,7 +78,7 @@ ZTEST(threads_scheduling, test_priority_cooperative)
  * preemptive thread which is of priority higher than current
  * thread. Make sure newly created thread is preempted
  *
- * @ingroup kernel_sched_tests
+ * @ingroup tests_kernel_sched
  */
 ZTEST(threads_scheduling, test_priority_preemptible)
 {
@@ -118,7 +118,7 @@ ZTEST(threads_scheduling, test_priority_preemptible)
  * higher than current thread. Make sure that the highest priority
  * and longest waiting thread is scheduled first.
  *
- * @ingroup kernel_sched_tests
+ * @ingroup tests_kernel_sched
  */
 ZTEST(threads_scheduling_1cpu, test_priority_preemptible_wait_prio)
 {
@@ -174,12 +174,22 @@ ZTEST(threads_scheduling_1cpu, test_priority_preemptible_wait_prio)
 extern void idle(void *p1, void *p2, void *p3);
 
 /**
- * Validate checking priority values
+ * @brief Verify thread priority validation accepts/rejects the right values.
  *
- * Our test cases don't cover every outcome of whether a priority is valid,
- * do so here.
+ * @details
+ * The kernel's priority-validity check must accept legal application priorities
+ * (and the idle priority only for the idle entry) and reject out-of-range
+ * values. The test runs a table of priority/entry combinations through both
+ * validity checks and confirms each expected accept/reject result.
  *
- * @ingroup kernel_sched_tests
+ * Test steps:
+ * - Iterate a table of {priority, entry, expected-valid} cases.
+ * - For each, check the internal validity predicate and the Z_VALID_PRIO macro.
+ *
+ * Expected result:
+ * - Every case returns its expected validity verdict.
+ *
+ * @ingroup tests_kernel_sched
  */
 ZTEST(threads_scheduling, test_bad_priorities)
 {

--- a/tests/kernel/sched/schedule_api/src/test_sched_timeslice_and_lock.c
+++ b/tests/kernel/sched/schedule_api/src/test_sched_timeslice_and_lock.c
@@ -90,7 +90,7 @@ static void thread_handler(void *p1, void *p2, void *p3)
  * @brief Validate the behavior of cooperative thread
  * when it yields
  *
- * @ingroup kernel_sched_tests
+ * @ingroup tests_kernel_sched
  *
  * @details Create 3 threads of priority -2, -1 and 0.
  * Yield the main thread which is cooperative. Check
@@ -121,7 +121,7 @@ ZTEST(threads_scheduling, test_yield_cooperative)
  * thread in timeout queue by calling k_sleep() which is cooperative.
  * Check if all the threads gets executed.
  *
- * @ingroup kernel_sched_tests
+ * @ingroup tests_kernel_sched
  */
 ZTEST(threads_scheduling, test_sleep_cooperative)
 {
@@ -140,6 +140,26 @@ ZTEST(threads_scheduling, test_sleep_cooperative)
 	teardown_threads();
 }
 
+/**
+ * @brief Verify k_busy_wait() in a cooperative thread blocks other threads.
+ *
+ * @details
+ * k_busy_wait() spins without yielding the CPU. From a cooperative thread (which
+ * is never preempted), no other ready thread may run for the whole busy-wait
+ * duration, unlike k_sleep() which would let them execute.
+ *
+ * Test steps:
+ * - Set the current thread to a cooperative priority and spawn worker threads.
+ * - Call k_busy_wait() for 100 ms.
+ * - Verify none of the workers executed during the busy-wait.
+ *
+ * Expected result:
+ * - No other thread runs while the cooperative thread busy-waits.
+ *
+ * @ingroup tests_kernel_sched
+ *
+ * @see k_busy_wait()
+ */
 ZTEST(threads_scheduling, test_busy_wait_cooperative)
 {
 	/* set current thread to a cooperative priority */
@@ -167,7 +187,7 @@ ZTEST(threads_scheduling, test_busy_wait_cooperative)
  *
  * @see k_wakeup()
  *
- * @ingroup kernel_sched_tests
+ * @ingroup tests_kernel_sched
  */
 ZTEST(threads_scheduling, test_sleep_wakeup_preemptible)
 {
@@ -206,7 +226,7 @@ static void coop_thread(void *p1, void *p2, void *p3)
  *
  * @see k_wakeup()
  *
- * @ingroup kernel_sched_tests
+ * @ingroup tests_kernel_sched
  */
 ZTEST(threads_scheduling, test_pending_thread_wakeup)
 {
@@ -241,7 +261,7 @@ ZTEST(threads_scheduling, test_pending_thread_wakeup)
  * time slice for threads with priority 0. Make sure the threads
  * with equal priorities are executed in time slice.
  *
- * @ingroup kernel_sched_tests
+ * @ingroup tests_kernel_sched
  */
 ZTEST(threads_scheduling, test_time_slicing_preemptible)
 {
@@ -280,7 +300,7 @@ ZTEST(threads_scheduling, test_time_slicing_preemptible)
  *
  * @see k_busy_wait()
  *
- * @ingroup kernel_sched_tests
+ * @ingroup tests_kernel_sched
  */
 ZTEST(threads_scheduling, test_time_slicing_disable_preemptible)
 {
@@ -312,7 +332,7 @@ ZTEST(threads_scheduling, test_time_slicing_disable_preemptible)
  * threads are not executed. Call k_sleep() and check if the threads
  * have executed.
  *
- * @ingroup kernel_sched_tests
+ * @ingroup tests_kernel_sched
  */
 ZTEST(threads_scheduling, test_lock_preemptible)
 {
@@ -347,7 +367,7 @@ ZTEST(threads_scheduling, test_lock_preemptible)
  *
  * @see k_sched_lock(), k_sched_unlock()
  *
- * @ingroup kernel_sched_tests
+ * @ingroup tests_kernel_sched
  */
 ZTEST(threads_scheduling, test_unlock_preemptible)
 {
@@ -384,7 +404,7 @@ ZTEST(threads_scheduling, test_unlock_preemptible)
  *
  * @see k_sched_lock(), k_sched_unlock()
  *
- * @ingroup kernel_sched_tests
+ * @ingroup tests_kernel_sched
  */
 ZTEST(threads_scheduling, test_unlock_nested_sched_lock)
 {
@@ -433,7 +453,7 @@ ZTEST(threads_scheduling, test_unlock_nested_sched_lock)
  *
  * @see k_wakeup()
  *
- * @ingroup kernel_sched_tests
+ * @ingroup tests_kernel_sched
  */
 ZTEST(threads_scheduling, test_wakeup_expired_timer_thread)
 {

--- a/tests/kernel/sched/schedule_api/src/test_sched_timeslice_reset.c
+++ b/tests/kernel/sched/schedule_api/src/test_sched_timeslice_reset.c
@@ -101,8 +101,13 @@ ZTEST(threads_scheduling, test_slice_reset)
 	/* disable timeslice */
 	k_sched_time_slice_set(0, K_PRIO_PREEMPT(0));
 
-	/* Cycle-domain length of half a slice for the busy-wait below. */
-	uint32_t half_slice_cyc = k_ticks_to_cyc_ceil32(HALF_SLICE_TICKS);
+	/* Size the busy-wait as a whole number of ticks using the driver's
+	 * real cycles per tick, floor(HW/ticks). Converting the half-slice
+	 * with the fractional ratio (k_ticks_to_cyc_ceil32()) would skew the
+	 * measured ticks where a tick isn't a whole number of cycles.
+	 */
+	uint32_t cyc_per_tick = k_ticks_to_cyc_floor32(1);
+	uint32_t half_slice_cyc = HALF_SLICE_TICKS * cyc_per_tick;
 
 	for (int j = 0; j < 2; j++) {
 		k_sem_reset(&sema);
@@ -127,7 +132,9 @@ ZTEST(threads_scheduling, test_slice_reset)
 		/* initialize reference timestamp */
 		ticks_delta(&elapsed_slice);
 
-		/* current thread (ztest native) consumed a half timeslice */
+		/* consume half a timeslice, timed on the free-running cycle
+		 * counter (independent of the tick interrupt)
+		 */
 		t32 = k_cycle_get_32();
 		while (k_cycle_get_32() - t32 < half_slice_cyc) {
 			Z_SPIN_DELAY(50);

--- a/tests/kernel/sched/schedule_api/src/test_sched_timeslice_reset.c
+++ b/tests/kernel/sched/schedule_api/src/test_sched_timeslice_reset.c
@@ -13,98 +13,59 @@
 
 BUILD_ASSERT(NUM_THREAD <= MAX_NUM_THREAD);
 
-/* slice size in millisecond */
-#define SLICE_SIZE 200
-/* busy for more than one slice */
-#define BUSY_MS (SLICE_SIZE + 20)
-/* a half timeslice */
-#define HALF_SLICE_SIZE (SLICE_SIZE >> 1)
-#define HALF_SLICE_SIZE_CYCLES                                                 \
-	((uint64_t)(HALF_SLICE_SIZE)*sys_clock_hw_cycles_per_sec() / 1000)
+/* slice size in milliseconds (kernel slicing API takes ms) */
+#define SLICE_SIZE_MS 200
+/* busy-wait duration: more than one slice so the slicer fires */
+#define BUSY_MS (SLICE_SIZE_MS + 20)
 
-/* Task switch tolerance ... */
-#if CONFIG_SYS_CLOCK_TICKS_PER_SEC >= 1000
-/* ... will not take more than 1 ms. */
-#define TASK_SWITCH_TOLERANCE (1)
-#else
-/* ... 1ms is faster than a tick, loosen tolerance to just over 1 tick */
-#define TASK_SWITCH_TOLERANCE (1100 / CONFIG_SYS_CLOCK_TICKS_PER_SEC)
-#endif
+/* All measurement bounds are expressed in ticks: that's the granularity
+ * at which preemptive scheduling happens. Each measured slice lands on
+ * exactly one of two tick values -- the configured slice or one tick
+ * later, due to z_add_timeout()'s "+1" round-up that guarantees an
+ * at-least-N tick delay.
+ */
+#define SLICE_TICKS k_ms_to_ticks_ceil32(SLICE_SIZE_MS)
+#define HALF_SLICE_TICKS (SLICE_TICKS / 2)
 
 K_SEM_DEFINE(sema, 0, NUM_THREAD);
-/* elapsed_slice taken by last thread */
-static uint32_t elapsed_slice;
+/* Reference timestamp (in ticks) for each measurement */
+static uint64_t elapsed_slice;
 static int thread_idx;
-
-static uint32_t cycles_delta(uint32_t *reftime)
-{
-	uint32_t now, delta;
-
-	now = k_cycle_get_32();
-	delta = now - *reftime;
-	*reftime = now;
-
-	return delta;
-}
 
 static void thread_time_slice(void *p1, void *p2, void *p3)
 {
-	uint32_t t = cycles_delta(&elapsed_slice);
-	uint32_t expected_slice_min, expected_slice_max;
-	uint32_t switch_tolerance_ticks =
-		k_ms_to_ticks_ceil32(TASK_SWITCH_TOLERANCE);
-
-	if (thread_idx == 0) {
-		/*
-		 * Thread number 0 releases CPU after HALF_SLICE_SIZE, and
-		 * expected to switch in less than the switching tolerance.
-		 */
-		expected_slice_min =
-			(uint64_t)(HALF_SLICE_SIZE - TASK_SWITCH_TOLERANCE) *
-			sys_clock_hw_cycles_per_sec() / 1000;
-		expected_slice_max =
-			(uint64_t)(HALF_SLICE_SIZE + TASK_SWITCH_TOLERANCE) *
-			sys_clock_hw_cycles_per_sec() / 1000;
-	} else {
-		/*
-		 * Other threads are sliced with tick granularity. Here, we
-		 * also expecting task switch below the switching tolerance.
-		 */
-		expected_slice_min =
-			(k_ms_to_ticks_floor32(SLICE_SIZE)
-			 - switch_tolerance_ticks)
-			* k_ticks_to_cyc_floor32(1);
-		expected_slice_max =
-			(k_ms_to_ticks_ceil32(SLICE_SIZE)
-			 + switch_tolerance_ticks)
-			* k_ticks_to_cyc_ceil32(1);
-	}
+	uint32_t tick_delta = ticks_delta(&elapsed_slice);
+	/*
+	 * Thread 0 picks up CPU when the main test thread voluntarily
+	 * yields halfway through its slice, so its elapsed measurement
+	 * spans the busy-wait of half a slice. The remaining threads see
+	 * the previous thread's full slice between successive wakeups.
+	 */
+	uint32_t expected = (thread_idx == 0) ? HALF_SLICE_TICKS : SLICE_TICKS;
 
 #ifdef CONFIG_DEBUG
-	TC_PRINT("thread[%d] elapsed slice: %d, expected: <%d, %d>\n",
-		 thread_idx, t, expected_slice_min, expected_slice_max);
+	TC_PRINT("thread[%d] elapsed: %u ticks, expected ~%u\n",
+		 thread_idx, tick_delta, expected);
 #endif
 
-	/* Before the assert, otherwise in case of fail the output
-	 * will give the impression that the same thread ran more than
-	 * once
+	/* Update before the assert so a failure log doesn't suggest the
+	 * same thread ran more than once.
 	 */
 	thread_idx = (thread_idx + 1) % NUM_THREAD;
 
-	/** TESTPOINT: timeslice should be reset for each preemptive thread */
 #ifndef CONFIG_COVERAGE_GCOV
-	zassert_true(t >= expected_slice_min,
-		     "timeslice too small, expected %u got %u",
-		     expected_slice_min, t);
-	zassert_true(t <= expected_slice_max,
-		     "timeslice too big, expected %u got %u",
-		     expected_slice_max, t);
+	/* TESTPOINT: a measured slice falls on either the configured tick
+	 * boundary or the next one (kernel "+1" round-up).
+	 */
+	zassert_between_inclusive(tick_delta, expected, expected + 1,
+				  "elapsed %u ticks, expected ~%u",
+				  tick_delta, expected);
 #else
-	(void)t;
+	(void)tick_delta;
 #endif /* CONFIG_COVERAGE_GCOV */
 
-	/* Keep the current thread busy for more than one slice, even though,
-	 * when timeslice used up the next thread should be scheduled in.
+	/* Keep this thread busy past one slice so the slicer fires and
+	 * hands the CPU to the next thread.
 	 */
 	spin_for_ms(BUSY_MS);
 	k_sem_give(&sema);
@@ -135,21 +96,8 @@ ZTEST(threads_scheduling, test_slice_reset)
 	/* disable timeslice */
 	k_sched_time_slice_set(0, K_PRIO_PREEMPT(0));
 
-	/* The slice size needs to be set in ms (which get converted
-	 * into ticks internally), but we want to loop over a half
-	 * slice in cycles. That requires a bit of care to be sure the
-	 * value divides properly.
-	 */
-	uint32_t slice_ticks = k_ms_to_ticks_ceil32(SLICE_SIZE);
-	uint32_t half_slice_cyc = k_ticks_to_cyc_ceil32(slice_ticks / 2);
-
-	if (slice_ticks % 2 != 0) {
-		uint32_t deviation = k_ticks_to_cyc_ceil32(1);
-		/* slice_ticks can't be divisible by two, so we add the
-		 * (slice_ticks / 2) floating part back to half_slice_cyc.
-		 */
-		half_slice_cyc = half_slice_cyc + (deviation / 2);
-	}
+	/* Cycle-domain length of half a slice for the busy-wait below. */
+	uint32_t half_slice_cyc = k_ticks_to_cyc_ceil32(HALF_SLICE_TICKS);
 
 	for (int j = 0; j < 2; j++) {
 		k_sem_reset(&sema);
@@ -169,10 +117,10 @@ ZTEST(threads_scheduling, test_slice_reset)
 		}
 
 		/* enable time slice (and reset the counter!) */
-		k_sched_time_slice_set(SLICE_SIZE, K_PRIO_PREEMPT(0));
+		k_sched_time_slice_set(SLICE_SIZE_MS, K_PRIO_PREEMPT(0));
 
 		/* initialize reference timestamp */
-		cycles_delta(&elapsed_slice);
+		ticks_delta(&elapsed_slice);
 
 		/* current thread (ztest native) consumed a half timeslice */
 		t32 = k_cycle_get_32();
@@ -181,7 +129,7 @@ ZTEST(threads_scheduling, test_slice_reset)
 		}
 
 		/* relinquish CPU and wait for each thread to complete */
-		k_sleep(K_TICKS(slice_ticks * (NUM_THREAD + 1)));
+		k_sleep(K_TICKS(SLICE_TICKS * (NUM_THREAD + 1)));
 		for (int i = 0; i < NUM_THREAD; i++) {
 			k_sem_take(&sema, K_FOREVER);
 		}

--- a/tests/kernel/sched/schedule_api/src/test_sched_timeslice_reset.c
+++ b/tests/kernel/sched/schedule_api/src/test_sched_timeslice_reset.c
@@ -71,6 +71,8 @@ static void thread_time_slice(void *p1, void *p2, void *p3)
 	k_sem_give(&sema);
 }
 
+#endif /* CONFIG_TIMESLICING */
+
 /* test cases */
 /**
  * @brief Check the behavior of preemptive threads when the
@@ -80,13 +82,16 @@ static void thread_time_slice(void *p1, void *p2, void *p3)
  * priorities and few with same priorities and enable the time slice.
  * Ensure that each thread is given the time slice period to execute.
  *
+ * Skipped when CONFIG_TIMESLICING is disabled.
+ *
  * @see k_sched_time_slice_set(), k_sem_reset(), k_cycle_get_32(),
  *      k_uptime_get_32()
  *
- * @ingroup kernel_sched_tests
+ * @ingroup tests_kernel_sched
  */
 ZTEST(threads_scheduling, test_slice_reset)
 {
+#ifdef CONFIG_TIMESLICING
 	uint32_t t32;
 	k_tid_t tid[NUM_THREAD];
 	struct k_thread t[NUM_THREAD];
@@ -142,11 +147,7 @@ ZTEST(threads_scheduling, test_slice_reset)
 		k_sched_time_slice_set(0, K_PRIO_PREEMPT(0));
 	}
 	k_thread_priority_set(k_current_get(), old_prio);
-}
-
-#else /* CONFIG_TIMESLICING */
-ZTEST(threads_scheduling, test_slice_reset)
-{
+#else
 	ztest_test_skip();
-}
 #endif /* CONFIG_TIMESLICING */
+}

--- a/tests/kernel/sched/schedule_api/src/test_sched_timeslice_reset.c
+++ b/tests/kernel/sched/schedule_api/src/test_sched_timeslice_reset.c
@@ -67,7 +67,7 @@ static void thread_time_slice(void *p1, void *p2, void *p3)
 	/* Keep this thread busy past one slice so the slicer fires and
 	 * hands the CPU to the next thread.
 	 */
-	spin_for_ms(BUSY_MS);
+	k_busy_wait(BUSY_MS * USEC_PER_MSEC);
 	k_sem_give(&sema);
 }
 

--- a/tests/kernel/sched/schedule_api/src/test_slice_scheduling.c
+++ b/tests/kernel/sched/schedule_api/src/test_slice_scheduling.c
@@ -87,8 +87,13 @@ static void slice_expired(struct k_thread *thread, void *data)
 {
 	zassert_equal(thread, data, "wrong callback data pointer");
 
+	/* Convert with the driver's real cycles per tick, floor(HW/ticks), not
+	 * the fractional ratio k_cyc_to_ticks_near32() uses (which skews where a
+	 * tick isn't a whole number of cycles). Round, don't truncate, to absorb
+	 * the sub-tick offset between the reference and this reading.
+	 */
 	uint32_t now = k_cycle_get_32();
-	uint32_t dt = k_cyc_to_ticks_near32(now - last_cyc);
+	uint32_t dt = DIV_ROUND_CLOSEST(now - last_cyc, k_ticks_to_cyc_floor32(1));
 
 	zassert_true(perthread_running, "thread didn't start");
 	/* Slice fire lands on either the configured tick boundary or

--- a/tests/kernel/sched/schedule_api/src/test_slice_scheduling.c
+++ b/tests/kernel/sched/schedule_api/src/test_slice_scheduling.c
@@ -22,17 +22,24 @@
 #define ITERATION_COUNT 5
 
 BUILD_ASSERT(NUM_THREAD <= MAX_NUM_THREAD);
-/* slice size in millisecond */
-#define SLICE_SIZE 200
+/* slice size in milliseconds (kernel slicing API takes ms) */
+#define SLICE_SIZE_MS 200
+/* busy-wait duration: more than one slice so the slicer fires */
+#define BUSY_MS (SLICE_SIZE_MS + 20)
+
+/* Measurement bound is in ticks: slicer-driven preemption lands on
+ * either the configured tick boundary or one tick later (kernel "+1"
+ * round-up in z_add_timeout()).
+ */
+#define SLICE_TICKS k_ms_to_ticks_ceil32(SLICE_SIZE_MS)
+
 #define PERTHREAD_SLICE_TICKS 64
-#define TICK_SLOP 4
-/* busy for more than one slice */
-#define BUSY_MS (SLICE_SIZE + 20)
+
 static struct k_thread t[NUM_THREAD];
 
 static K_SEM_DEFINE(sema1, 0, NUM_THREAD);
-/* elapsed_slice taken by last thread */
-static int64_t elapsed_slice;
+/* Reference timestamp (in ticks) for measuring slice durations */
+static uint64_t elapsed_slice;
 
 static int thread_idx;
 
@@ -44,34 +51,30 @@ static void thread_tslice(void *p1, void *p2, void *p3)
 	int thread_parameter = (idx == (NUM_THREAD - 1)) ? '\n' :
 			       (idx + 'A');
 
-	int64_t expected_slice_min = k_ticks_to_ms_floor64(k_ms_to_ticks_ceil32(SLICE_SIZE) - 1);
-	int64_t expected_slice_max = k_ticks_to_ms_ceil64(k_ms_to_ticks_ceil32(SLICE_SIZE) + 1);
-
-	/* Clumsy, but need to handle the precision loss with
-	 * submillisecond ticks.  It's always possible to alias and
-	 * produce a tdelta of "1", no matter how fast ticks are.
-	 */
-	if (expected_slice_max == expected_slice_min) {
-		expected_slice_max = expected_slice_min + 1;
-	}
-
 	while (1) {
-		int64_t tdelta = k_uptime_delta(&elapsed_slice);
+		uint32_t tick_delta = ticks_delta(&elapsed_slice);
+
 		TC_PRINT("%c", thread_parameter);
-		/* Test Fails if thread exceed allocated time slice or
-		 * Any thread is scheduled out of order.
+		/* Threads must run in round-robin order. */
+		zassert_equal(idx, thread_idx,
+			      "out of order: idx=%d thread_idx=%d",
+			      idx, thread_idx);
+		/* Each measured slice falls on either the configured tick
+		 * boundary or the next one (kernel "+1" round-up).
 		 */
-		zassert_true(((tdelta >= expected_slice_min) &&
-			      (tdelta <= expected_slice_max) &&
-			      (idx == thread_idx)), NULL);
+		zassert_between_inclusive(tick_delta, SLICE_TICKS,
+					  SLICE_TICKS + 1,
+					  "tick_delta=%u expected ~%u",
+					  tick_delta, SLICE_TICKS);
 		thread_idx = (thread_idx + 1) % (NUM_THREAD);
+
+		k_sem_give(&sema1);
 
 		/* Keep the current thread busy for more than one slice,
 		 * even though, when timeslice used up the next thread
 		 * should be scheduled in.
 		 */
 		spin_for_ms(BUSY_MS);
-		k_sem_give(&sema1);
 	}
 }
 
@@ -101,6 +104,9 @@ ZTEST(threads_scheduling, test_slice_scheduling)
 	/* update priority for current thread */
 	k_thread_priority_set(k_current_get(), K_PRIO_PREEMPT(BASE_PRIORITY));
 
+	/* align to tick edge */
+	k_usleep(1);
+
 	/* create threads with equal preemptive priority */
 	for (int i = 0; i < NUM_THREAD; i++) {
 		tid[i] = k_thread_create(&t[i], tstacks[i], STACK_SIZE,
@@ -111,20 +117,21 @@ ZTEST(threads_scheduling, test_slice_scheduling)
 	}
 
 	/* enable time slice */
-	k_sched_time_slice_set(SLICE_SIZE, K_PRIO_PREEMPT(BASE_PRIORITY));
+	k_sched_time_slice_set(SLICE_SIZE_MS, K_PRIO_PREEMPT(BASE_PRIORITY));
+	ticks_delta(&elapsed_slice);
 
 	while (count < ITERATION_COUNT) {
-		k_uptime_delta(&elapsed_slice);
-
 		/* Keep the current thread busy for more than one slice,
 		 * even though, when timeslice used up the next thread
 		 * should be scheduled in.
 		 */
 		spin_for_ms(BUSY_MS);
 
-		/* relinquish CPU and wait for each thread to complete */
+		/* all threads should have run by now */
+		ticks_delta(&elapsed_slice);
 		for (int i = 0; i < NUM_THREAD; i++) {
-			k_sem_take(&sema1, K_FOREVER);
+			zassert_equal(k_sem_take(&sema1, K_NO_WAIT), 0,
+				      "not all threads gave their sem");
 		}
 		count++;
 	}
@@ -154,10 +161,13 @@ static void slice_expired(struct k_thread *thread, void *data)
 	uint32_t dt = k_cyc_to_ticks_near32(now - last_cyc);
 
 	zassert_true(perthread_running, "thread didn't start");
-	zassert_true(dt >= (PERTHREAD_SLICE_TICKS - TICK_SLOP),
-		     "slice expired >%d ticks too soon (dt=%d)", TICK_SLOP, dt);
-	zassert_true((dt - PERTHREAD_SLICE_TICKS) <= TICK_SLOP,
-		     "slice expired >%d ticks late (dt=%d)", TICK_SLOP, dt);
+	/* Slice fire lands on either the configured tick boundary or
+	 * the next one due to z_add_timeout()'s "+1" round-up.
+	 */
+	zassert_between_inclusive(dt, PERTHREAD_SLICE_TICKS,
+				  PERTHREAD_SLICE_TICKS + 1,
+				  "slice expired at dt=%u, expected ~%u",
+				  dt, PERTHREAD_SLICE_TICKS);
 
 	last_cyc = now;
 

--- a/tests/kernel/sched/schedule_api/src/test_slice_scheduling.c
+++ b/tests/kernel/sched/schedule_api/src/test_slice_scheduling.c
@@ -78,6 +78,51 @@ static void thread_tslice(void *p1, void *p2, void *p3)
 	}
 }
 
+static volatile int32_t perthread_count;
+static volatile uint32_t last_cyc;
+static volatile bool perthread_running;
+static K_SEM_DEFINE(perthread_sem, 0, 1);
+
+static void slice_expired(struct k_thread *thread, void *data)
+{
+	zassert_equal(thread, data, "wrong callback data pointer");
+
+	uint32_t now = k_cycle_get_32();
+	uint32_t dt = k_cyc_to_ticks_near32(now - last_cyc);
+
+	zassert_true(perthread_running, "thread didn't start");
+	/* Slice fire lands on either the configured tick boundary or
+	 * the next one due to z_add_timeout()'s "+1" round-up.
+	 */
+	zassert_between_inclusive(dt, PERTHREAD_SLICE_TICKS,
+				  PERTHREAD_SLICE_TICKS + 1,
+				  "slice expired at dt=%u, expected ~%u",
+				  dt, PERTHREAD_SLICE_TICKS);
+
+	last_cyc = now;
+
+	/* First time through, just let the slice expire and keep
+	 * running.  Second time, abort the thread and wake up the
+	 * main test function.
+	 */
+	if (perthread_count++ != 0) {
+		k_thread_abort(thread);
+		perthread_running = false;
+		k_sem_give(&perthread_sem);
+	}
+}
+
+static void slice_perthread_fn(void *a, void *b, void *c)
+{
+	ARG_UNUSED(a); ARG_UNUSED(b); ARG_UNUSED(c);
+	while (true) {
+		perthread_running = true;
+		k_busy_wait(10);
+	}
+}
+
+#endif /* CONFIG_TIMESLICING */
+
 /* test cases */
 
 /**
@@ -88,10 +133,15 @@ static void thread_tslice(void *p1, void *p2, void *p3)
  * and few with same priorities and enable the time slice.
  * Ensure that each thread is given the time slice period to execute.
  *
- * @ingroup kernel_sched_tests
+ * Skipped when CONFIG_TIMESLICING is disabled.
+ *
+ * @ingroup tests_kernel_sched
+ *
+ * @see k_sched_time_slice_set()
  */
 ZTEST(threads_scheduling, test_slice_scheduling)
 {
+#ifdef CONFIG_TIMESLICING
 	k_tid_t tid[NUM_THREAD];
 	int old_prio = k_thread_priority_get(k_current_get());
 	int count = 0;
@@ -146,53 +196,36 @@ ZTEST(threads_scheduling, test_slice_scheduling)
 	k_sched_time_slice_set(0, K_PRIO_PREEMPT(0));
 
 	k_thread_priority_set(k_current_get(), old_prio);
+#else
+	ztest_test_skip();
+#endif /* CONFIG_TIMESLICING */
 }
 
-static volatile int32_t perthread_count;
-static volatile uint32_t last_cyc;
-static volatile bool perthread_running;
-static K_SEM_DEFINE(perthread_sem, 0, 1);
-
-static void slice_expired(struct k_thread *thread, void *data)
-{
-	zassert_equal(thread, data, "wrong callback data pointer");
-
-	uint32_t now = k_cycle_get_32();
-	uint32_t dt = k_cyc_to_ticks_near32(now - last_cyc);
-
-	zassert_true(perthread_running, "thread didn't start");
-	/* Slice fire lands on either the configured tick boundary or
-	 * the next one due to z_add_timeout()'s "+1" round-up.
-	 */
-	zassert_between_inclusive(dt, PERTHREAD_SLICE_TICKS,
-				  PERTHREAD_SLICE_TICKS + 1,
-				  "slice expired at dt=%u, expected ~%u",
-				  dt, PERTHREAD_SLICE_TICKS);
-
-	last_cyc = now;
-
-	/* First time through, just let the slice expire and keep
-	 * running.  Second time, abort the thread and wake up the
-	 * main test function.
-	 */
-	if (perthread_count++ != 0) {
-		k_thread_abort(thread);
-		perthread_running = false;
-		k_sem_give(&perthread_sem);
-	}
-}
-
-static void slice_perthread_fn(void *a, void *b, void *c)
-{
-	ARG_UNUSED(a); ARG_UNUSED(b); ARG_UNUSED(c);
-	while (true) {
-		perthread_running = true;
-		k_busy_wait(10);
-	}
-}
-
+/**
+ * @brief Verify a per-thread time slice expires and invokes its callback.
+ *
+ * @details
+ * With CONFIG_TIMESLICE_PER_THREAD, a thread's individual time slice
+ * (k_thread_time_slice_set()) must expire after the configured number of ticks
+ * and invoke the registered expiry callback, which here suspends the thread.
+ * Requires CONFIG_TIMESLICING and CONFIG_TIMESLICE_PER_THREAD; otherwise the
+ * test skips.
+ *
+ * Test steps:
+ * - Create a busy-looping thread and set a per-thread slice with a callback.
+ * - Tick-align and start the thread.
+ * - Wait for the callback (which suspends the thread) and confirm it stopped.
+ *
+ * Expected result:
+ * - The per-thread slice expires, the callback runs, and the thread is suspended.
+ *
+ * @ingroup tests_kernel_sched
+ *
+ * @see k_thread_time_slice_set()
+ */
 ZTEST(threads_scheduling, test_slice_perthread)
 {
+#ifdef CONFIG_TIMESLICING
 	if (!IS_ENABLED(CONFIG_TIMESLICE_PER_THREAD)) {
 		ztest_test_skip();
 		return;
@@ -211,15 +244,7 @@ ZTEST(threads_scheduling, test_slice_perthread)
 
 	k_sem_take(&perthread_sem, K_FOREVER);
 	zassert_false(perthread_running, "thread failed to suspend");
-}
-
-#else /* CONFIG_TIMESLICING */
-ZTEST(threads_scheduling, test_slice_scheduling)
-{
+#else
 	ztest_test_skip();
-}
-ZTEST(threads_scheduling, test_slice_perthread)
-{
-	ztest_test_skip();
-}
 #endif /* CONFIG_TIMESLICING */
+}

--- a/tests/kernel/sched/schedule_api/src/test_slice_scheduling.c
+++ b/tests/kernel/sched/schedule_api/src/test_slice_scheduling.c
@@ -69,12 +69,11 @@ static void thread_tslice(void *p1, void *p2, void *p3)
 		thread_idx = (thread_idx + 1) % (NUM_THREAD);
 
 		k_sem_give(&sema1);
-
 		/* Keep the current thread busy for more than one slice,
 		 * even though, when timeslice used up the next thread
 		 * should be scheduled in.
 		 */
-		spin_for_ms(BUSY_MS);
+		k_busy_wait(BUSY_MS * USEC_PER_MSEC);
 	}
 }
 
@@ -180,7 +179,7 @@ ZTEST(threads_scheduling, test_slice_scheduling)
 		 * even though, when timeslice used up the next thread
 		 * should be scheduled in.
 		 */
-		spin_for_ms(BUSY_MS);
+		k_busy_wait(BUSY_MS * USEC_PER_MSEC);
 
 		/* all threads should have run by now */
 		ticks_delta(&elapsed_slice);

--- a/tests/kernel/sched/schedule_api/src/user_api.c
+++ b/tests/kernel/sched/schedule_api/src/user_api.c
@@ -29,6 +29,25 @@ static void sleepy_thread(void *p1, void *p2, void *p3)
 	k_sem_give(&user_sem);
 }
 
+/**
+ * @brief Verify k_wakeup() wakes a sleeping thread from user mode.
+ *
+ * @details
+ * A user-mode thread must be able to wake another thread that is blocked in
+ * k_sleep(K_FOREVER) by calling k_wakeup(). The woken thread proceeds and
+ * signals completion.
+ *
+ * Test steps:
+ * - From a user thread, spawn a user thread that sleeps forever.
+ * - Call k_wakeup() on it and wait for it to signal it resumed.
+ *
+ * Expected result:
+ * - The sleeping thread is woken and runs to completion.
+ *
+ * @ingroup tests_kernel_sched
+ *
+ * @see k_wakeup()
+ */
 ZTEST_USER(threads_scheduling, test_user_k_wakeup)
 {
 	k_tid_t tid = k_thread_create(&user_thread, ustack, STACK_SIZE, sleepy_thread,
@@ -52,6 +71,26 @@ static void preempt_test_thread(void *p1, void *p2, void *p3)
 	k_sem_give(&user_sem);
 }
 
+/**
+ * @brief Verify k_is_preempt_thread() reflects priority from user mode.
+ *
+ * @details
+ * k_is_preempt_thread() must report false for a cooperative-priority thread and
+ * true for a preemptible-priority thread, when queried from user mode. The test
+ * spawns a worker at each priority class and checks the reported value.
+ *
+ * Test steps:
+ * - Spawn a user worker at the (cooperative) caller priority; expect false.
+ * - Spawn a user worker at a preemptible priority; expect true.
+ *
+ * Expected result:
+ * - k_is_preempt_thread() is false for the cooperative thread and true for the
+ *   preemptible one.
+ *
+ * @ingroup tests_kernel_sched
+ *
+ * @see k_is_preempt_thread()
+ */
 ZTEST_USER(threads_scheduling, test_user_k_is_preempt)
 {
 	/* thread_was_preempt is volatile, and static analysis doesn't
@@ -89,9 +128,13 @@ ZTEST_USER(threads_scheduling, test_user_k_is_preempt)
 	k_thread_abort(tid);
 }
 
-/**
- * userspace negative test: take NULL as input param to verify
- * the api will trigger a fatal exception
+/*
+ * The tests below are userspace negative tests: they pass NULL (or an
+ * out-of-range value) to an API to verify it triggers a fatal exception. They
+ * only make sense under CONFIG_USERSPACE; on other configurations each test
+ * skips. The guard lives inside the single test body (rather than a duplicate
+ * stub definition) and around the fault-helper thread to avoid an unused
+ * function warning.
  */
 #ifdef CONFIG_USERSPACE
 static void thread_suspend_init_null(void *p1, void *p2, void *p3)
@@ -106,19 +149,21 @@ static void thread_suspend_init_null(void *p1, void *p2, void *p3)
 	/* should not go here */
 	ztest_test_fail();
 }
+#endif
 
 /**
  * @brief Test k_thread_suspend() API
  *
  * @details Create a thread and set k_thread_suspend() input param to NULL
- * will trigger a fatal error.
+ * will trigger a fatal error. Skipped when CONFIG_USERSPACE is disabled.
  *
- * @ingroup kernel_sched_tests
+ * @ingroup tests_kernel_sched
  *
  * @see k_thread_suspend()
  */
 ZTEST_USER(threads_scheduling, test_k_thread_suspend_init_null)
 {
+#ifdef CONFIG_USERSPACE
 	k_tid_t tid = k_thread_create(&user_thread, ustack, STACK_SIZE,
 			thread_suspend_init_null,
 			NULL, NULL, NULL,
@@ -126,13 +171,10 @@ ZTEST_USER(threads_scheduling, test_k_thread_suspend_init_null)
 			K_USER | K_INHERIT_PERMS, K_NO_WAIT);
 
 	k_thread_join(tid, K_FOREVER);
-}
 #else
-ZTEST_USER(threads_scheduling, test_k_thread_suspend_init_null)
-{
 	ztest_test_skip();
-}
 #endif
+}
 
 #ifdef CONFIG_USERSPACE
 static void thread_resume_init_null(void *p1, void *p2, void *p3)
@@ -147,19 +189,21 @@ static void thread_resume_init_null(void *p1, void *p2, void *p3)
 	/* should not go here */
 	ztest_test_fail();
 }
+#endif
 
 /**
  * @brief Test k_thread_resume() API
  *
  * @details Create a thread and set k_thread_resume() input param to NULL
- * will trigger a fatal error.
+ * will trigger a fatal error. Skipped when CONFIG_USERSPACE is disabled.
  *
- * @ingroup kernel_sched_tests
+ * @ingroup tests_kernel_sched
  *
  * @see k_thread_resume()
  */
 ZTEST_USER(threads_scheduling, test_k_thread_resume_init_null)
 {
+#ifdef CONFIG_USERSPACE
 	k_tid_t tid = k_thread_create(&user_thread, ustack, STACK_SIZE,
 			thread_resume_init_null,
 			NULL, NULL, NULL,
@@ -167,13 +211,10 @@ ZTEST_USER(threads_scheduling, test_k_thread_resume_init_null)
 			K_USER | K_INHERIT_PERMS, K_NO_WAIT);
 
 	k_thread_join(tid, K_FOREVER);
-}
 #else
-ZTEST_USER(threads_scheduling, test_k_thread_resume_init_null)
-{
 	ztest_test_skip();
-}
 #endif
+}
 
 #ifdef CONFIG_USERSPACE
 static void thread_priority_get_init_null(void *p1, void *p2, void *p3)
@@ -188,19 +229,21 @@ static void thread_priority_get_init_null(void *p1, void *p2, void *p3)
 	/* should not go here */
 	ztest_test_fail();
 }
+#endif
 
 /**
  * @brief Test k_thread_priority_get() API
  *
  * @details Create a thread and set thread_k_thread_priority_get() param input to
- * NULL will trigger a fatal error.
+ * NULL will trigger a fatal error. Skipped when CONFIG_USERSPACE is disabled.
  *
- * @ingroup kernel_sched_tests
+ * @ingroup tests_kernel_sched
  *
- * @see thread_k_thread_priority_get()
+ * @see k_thread_priority_get()
  */
 ZTEST_USER(threads_scheduling, test_k_thread_priority_get_init_null)
 {
+#ifdef CONFIG_USERSPACE
 	k_tid_t tid = k_thread_create(&user_thread, ustack, STACK_SIZE,
 			thread_priority_get_init_null,
 			NULL, NULL, NULL,
@@ -208,13 +251,10 @@ ZTEST_USER(threads_scheduling, test_k_thread_priority_get_init_null)
 			K_USER | K_INHERIT_PERMS, K_NO_WAIT);
 
 	k_thread_join(tid, K_FOREVER);
-}
 #else
-ZTEST_USER(threads_scheduling, test_k_thread_priority_get_init_null)
-{
 	ztest_test_skip();
-}
 #endif
+}
 
 #ifdef CONFIG_USERSPACE
 static void thread_priority_set_init_null(void *p1, void *p2, void *p3)
@@ -229,19 +269,21 @@ static void thread_priority_set_init_null(void *p1, void *p2, void *p3)
 	/* should not go here */
 	ztest_test_fail();
 }
+#endif
 
 /**
- * @brief Test k_thread_priority_set() API
+ * @brief Test k_thread_priority_set() with a NULL thread.
  *
  * @details Create a thread and set k_thread_priority_set() param input to
- * NULL will trigger a fatal error.
+ * NULL will trigger a fatal error. Skipped when CONFIG_USERSPACE is disabled.
  *
- * @ingroup kernel_sched_tests
+ * @ingroup tests_kernel_sched
  *
  * @see k_thread_priority_set()
  */
 ZTEST_USER(threads_scheduling, test_k_thread_priority_set_init_null)
 {
+#ifdef CONFIG_USERSPACE
 	k_tid_t tid = k_thread_create(&user_thread, ustack, STACK_SIZE,
 			thread_priority_set_init_null,
 			NULL, NULL, NULL,
@@ -249,13 +291,10 @@ ZTEST_USER(threads_scheduling, test_k_thread_priority_set_init_null)
 			K_USER | K_INHERIT_PERMS, K_NO_WAIT);
 
 	k_thread_join(tid, K_FOREVER);
-}
 #else
-ZTEST_USER(threads_scheduling, test_k_thread_priority_set_init_null)
-{
 	ztest_test_skip();
-}
 #endif
+}
 
 #ifdef CONFIG_USERSPACE
 static void thread_priority_set_overmax(void *p1, void *p2, void *p3)
@@ -272,18 +311,21 @@ static void thread_priority_set_overmax(void *p1, void *p2, void *p3)
 	/* should not go here */
 	ztest_test_fail();
 }
+#endif
 
 /**
- * @brief Test k_thread_priority_set() API
+ * @brief Test k_thread_priority_set() with an out-of-range priority.
  *
- * @details Check input param range overmax in userspace test.
+ * @details Check input param range overmax in userspace test. Skipped when
+ * CONFIG_USERSPACE is disabled.
  *
- * @ingroup kernel_sched_tests
+ * @ingroup tests_kernel_sched
  *
  * @see k_thread_priority_set()
  */
 ZTEST_USER(threads_scheduling, test_k_thread_priority_set_overmax)
 {
+#ifdef CONFIG_USERSPACE
 	k_tid_t tid = k_thread_create(&user_thread, ustack, STACK_SIZE,
 			thread_priority_set_overmax,
 			NULL, NULL, NULL,
@@ -291,13 +333,10 @@ ZTEST_USER(threads_scheduling, test_k_thread_priority_set_overmax)
 			K_USER | K_INHERIT_PERMS, K_NO_WAIT);
 
 	k_thread_join(tid, K_FOREVER);
-}
 #else
-ZTEST_USER(threads_scheduling, test_k_thread_priority_set_overmax)
-{
 	ztest_test_skip();
-}
 #endif
+}
 
 #ifdef CONFIG_USERSPACE
 static void thread_priority_set_upgrade(void *p1, void *p2, void *p3)
@@ -316,18 +355,21 @@ static void thread_priority_set_upgrade(void *p1, void *p2, void *p3)
 	/* should not go here */
 	ztest_test_fail();
 }
+#endif
 
 /**
- * @brief Test k_thread_priority_set() API
+ * @brief Test that a user thread cannot raise its own priority.
  *
- * @details Check input param range fail in userspace test.
+ * @details Check input param range fail in userspace test. Skipped when
+ * CONFIG_USERSPACE is disabled.
  *
- * @ingroup kernel_sched_tests
+ * @ingroup tests_kernel_sched
  *
  * @see k_thread_priority_set()
  */
 ZTEST_USER(threads_scheduling, test_k_thread_priority_set_upgrade)
 {
+#ifdef CONFIG_USERSPACE
 	k_tid_t tid = k_thread_create(&user_thread, ustack, STACK_SIZE,
 			thread_priority_set_upgrade,
 			NULL, NULL, NULL,
@@ -335,13 +377,10 @@ ZTEST_USER(threads_scheduling, test_k_thread_priority_set_upgrade)
 			K_USER | K_INHERIT_PERMS, K_NO_WAIT);
 
 	k_thread_join(tid, K_FOREVER);
-}
 #else
-ZTEST_USER(threads_scheduling, test_k_thread_priority_set_upgrade)
-{
 	ztest_test_skip();
-}
 #endif
+}
 
 #ifdef CONFIG_USERSPACE
 static void thread_wakeup_init_null(void *p1, void *p2, void *p3)
@@ -356,19 +395,21 @@ static void thread_wakeup_init_null(void *p1, void *p2, void *p3)
 	/* should not go here */
 	ztest_test_fail();
 }
+#endif
 
 /**
- * @brief Test k_wakeup() API
+ * @brief Test k_wakeup() with a NULL thread.
  *
  * @details Create a thread and set k_wakeup() input param to NULL
- * will trigger a fatal error
+ * will trigger a fatal error. Skipped when CONFIG_USERSPACE is disabled.
  *
- * @ingroup kernel_sched_tests
+ * @ingroup tests_kernel_sched
  *
  * @see k_wakeup()
  */
 ZTEST_USER(threads_scheduling, test_k_wakeup_init_null)
 {
+#ifdef CONFIG_USERSPACE
 	k_tid_t tid = k_thread_create(&user_thread, ustack, STACK_SIZE,
 			thread_wakeup_init_null,
 			NULL, NULL, NULL,
@@ -376,10 +417,7 @@ ZTEST_USER(threads_scheduling, test_k_wakeup_init_null)
 			K_USER | K_INHERIT_PERMS, K_NO_WAIT);
 
 	k_thread_join(tid, K_FOREVER);
-}
 #else
-ZTEST_USER(threads_scheduling, test_k_wakeup_init_null)
-{
 	ztest_test_skip();
-}
 #endif
+}

--- a/tests/kernel/sched/wraparound/src/main.c
+++ b/tests/kernel/sched/wraparound/src/main.c
@@ -16,7 +16,27 @@ static void alarm_callback(struct k_timer *timer)
 K_TIMER_DEFINE(alarm, alarm_callback, NULL);
 
 /**
- * @brief Test 32-bit tick wraparound during k_sleep() execution
+ * @brief Verify k_sleep() handles a 32-bit tick counter wraparound correctly.
+ *
+ * @details
+ * When the system tick counter wraps around 2^32 while a thread is sleeping, the
+ * timeout math must remain correct so an early k_wakeup() is honored and the
+ * reported remaining time is sane. The tick counter is preset close to the wrap
+ * point, a timer wakes the sleeper before its long timeout, and the test checks
+ * the sleep returned early with a plausible remaining duration.
+ *
+ * Test steps:
+ * - Set the tick counter just below the 32-bit wrap point.
+ * - Sleep for a long timeout while a timer fires an early k_wakeup().
+ * - Verify k_sleep() returned with the expected non-zero remaining time.
+ *
+ * Expected result:
+ * - The sleep is woken early across the tick wraparound with correct accounting.
+ *
+ * @ingroup tests_kernel_sched
+ *
+ * @see k_sleep()
+ * @see k_wakeup()
  */
 ZTEST(wraparound, test_tick_wraparound_in_sleep)
 {

--- a/tests/kernel/tickless/tickless_concept/src/main.c
+++ b/tests/kernel/tickless/tickless_concept/src/main.c
@@ -12,19 +12,17 @@
 static K_THREAD_STACK_ARRAY_DEFINE(tstack, NUM_THREAD, STACK_SIZE);
 static struct k_thread tdata[NUM_THREAD];
 
-#define IDLE_THRESH k_ms_to_ticks_floor64(200)
+/* Sleep duration for the tickless / tickful cases, in milliseconds (the
+ * unit kernel sleep APIs accept).
+ */
+#define SLEEP_TICKLESS_MS  k_ticks_to_ms_floor64(k_ms_to_ticks_floor64(200))
+#define SLEEP_TICKFUL_MS   k_ticks_to_ms_floor64(k_ms_to_ticks_floor64(200) - 1)
 
-/*sleep duration tickless*/
-#define SLEEP_TICKLESS	 k_ticks_to_ms_floor64(IDLE_THRESH)
-
-/*sleep duration with tick*/
-#define SLEEP_TICKFUL	 k_ticks_to_ms_floor64(IDLE_THRESH - 1)
-
-/*slice size is set as half of the sleep duration*/
-#define SLICE_SIZE	 k_ticks_to_ms_floor64(IDLE_THRESH >> 1)
-
-/*maximum slice duration accepted by the test*/
-#define SLICE_SIZE_LIMIT k_ticks_to_ms_floor64((IDLE_THRESH >> 1) + 1)
+/* Slice is half of the sleep duration.  Defined in ms (kernel slicing
+ * API takes ms) and ticks (measurements compare in ticks).
+ */
+#define SLICE_SIZE_MS      (SLEEP_TICKLESS_MS / 2)
+#define SLICE_TICKS        k_ms_to_ticks_ceil32(SLICE_SIZE_MS)
 
 /*align to millisecond boundary*/
 #define ALIGN_MS_BOUNDARY()		       \
@@ -35,22 +33,34 @@ static struct k_thread tdata[NUM_THREAD];
 	} while (0)
 
 K_SEM_DEFINE(sema, 0, NUM_THREAD);
-static int64_t elapsed_slice;
+/* Reference timestamp (in ticks) for measuring slice durations */
+static uint64_t elapsed_slice;
+
+static uint32_t ticks_delta(uint64_t *reftime)
+{
+	uint64_t now = k_uptime_ticks();
+	uint32_t delta = now - *reftime;
+
+	*reftime = now;
+	return delta;
+}
 
 static void thread_tslice(void *p1, void *p2, void *p3)
 {
-	int64_t t = k_uptime_delta(&elapsed_slice);
+	uint32_t tick_delta = ticks_delta(&elapsed_slice);
 
-	TC_PRINT("elapsed slice %" PRId64 ", expected: <%" PRId64 ", %" PRId64 ">\n",
-		t, SLICE_SIZE, SLICE_SIZE_LIMIT);
+	TC_PRINT("elapsed slice %u ticks, expected ~%u\n",
+		 tick_delta, (uint32_t)SLICE_TICKS);
 
-	/**TESTPOINT: verify slicing scheduler behaves as expected*/
-	zassert_true(t >= SLICE_SIZE);
-	/*less than one tick delay*/
-	zassert_true(t <= SLICE_SIZE_LIMIT);
+	/* TESTPOINT: a measured slice falls on either the configured tick
+	 * boundary or the next one (kernel "+1" round-up).
+	 */
+	zassert_between_inclusive(tick_delta, SLICE_TICKS, SLICE_TICKS + 1,
+				  "elapsed %u ticks, expected ~%u",
+				  tick_delta, (uint32_t)SLICE_TICKS);
 
 	/*keep the current thread busy for more than one slice*/
-	k_busy_wait(1000 * SLEEP_TICKLESS);
+	k_busy_wait(1000 * SLEEP_TICKLESS_MS);
 	k_sem_give(&sema);
 }
 /**
@@ -72,19 +82,19 @@ ZTEST(tickless_concept, test_tickless_sysclock)
 
 	ALIGN_MS_BOUNDARY();
 	t0 = k_uptime_get_32();
-	k_msleep(SLEEP_TICKLESS);
+	k_msleep(SLEEP_TICKLESS_MS);
 	t1 = k_uptime_get_32();
 	TC_PRINT("time %d, %d\n", t0, t1);
 	/**TESTPOINT: verify system clock recovery after exiting tickless idle*/
-	zassert_true((t1 - t0) >= SLEEP_TICKLESS);
+	zassert_true((t1 - t0) >= SLEEP_TICKLESS_MS);
 
 	ALIGN_MS_BOUNDARY();
 	t0 = k_uptime_get_32();
-	k_sem_take(&sema, K_MSEC(SLEEP_TICKFUL));
+	k_sem_take(&sema, K_MSEC(SLEEP_TICKFUL_MS));
 	t1 = k_uptime_get_32();
 	TC_PRINT("time %d, %d\n", t0, t1);
 	/**TESTPOINT: verify system clock recovery after exiting tickful idle*/
-	zassert_true((t1 - t0) >= SLEEP_TICKFUL);
+	zassert_true((t1 - t0) >= SLEEP_TICKFUL_MS);
 }
 
 /**
@@ -99,16 +109,16 @@ ZTEST(tickless_concept, test_tickless_slice)
 
 	k_sem_reset(&sema);
 	/*enable time slice*/
-	k_sched_time_slice_set(SLICE_SIZE, K_PRIO_PREEMPT(0));
+	k_sched_time_slice_set(SLICE_SIZE_MS, K_PRIO_PREEMPT(0));
 
 	/*create delayed threads with equal preemptive priority*/
 	for (int i = 0; i < NUM_THREAD; i++) {
 		tid[i] = k_thread_create(&tdata[i], tstack[i], STACK_SIZE,
 					 thread_tslice, NULL, NULL, NULL,
 					 K_PRIO_PREEMPT(0), 0,
-					 K_MSEC(SLICE_SIZE));
+					 K_MSEC(SLICE_SIZE_MS));
 	}
-	k_uptime_delta(&elapsed_slice);
+	ticks_delta(&elapsed_slice);
 	/*relinquish CPU and wait for each thread to complete*/
 	for (int i = 0; i < NUM_THREAD; i++) {
 		k_sem_take(&sema, K_FOREVER);


### PR DESCRIPTION

  ## Overview

  This PR cherry-picks a series of upstream fixes and improvements targeting
  Cortex-M SysTick timer accuracy, kernel timeout/timeslicing correctness, and
  scheduler test robustness. It also adds a Realtek Bee–specific fix for
  time-slice scheduling failures caused by a known SysTick hardware bug.

  ## Changes

  ### Cortex-M SysTick driver improvements

  - **`drivers: timer: cortex_m_systick: add zephyr,min-timeout-cycles property`**
    Allow DT-based override of the MIN_DELAY floor, useful for platforms with
    low-frequency clock sources such as 32 kHz.

  - **`dts: arm: realtek: bee: configure SysTick min-timeout-cycles`**
    Set the override to 32 cycles for RTL8752H and RTL87x2G, preventing the
    default 1024-cycle floor from imposing a ~31 ms minimum timeout.

  - **`drivers: timer: cortex_m_systick: use absolute-cycle deadlines`**
    Program SysTick using absolute cycle targets (matching the RISC-V and ARM
    generic timer drivers) to avoid accumulated error from reconstructing a
    tick-aligned fire point on every call.

  - **`drivers: timer: move the LPM_COMPANION_COUNTER hooks to common code`**
    Extract the low-power companion counter interface from cortex_m_systick into
    a shared file, making it available to other timer drivers.

  - **`kernel: timeout: make the system clock tick interface unsigned`**
    Partial cherry-pick of upstream f4a2a270715b: change the tick interface
    types to unsigned in cortex_m_systick, sys_clock_init, system_timer.h and
    kernel/timeout.c.

  - **`drivers: timer: drop dead K_TICKS_FOREVER tick clamps`**
    Partial cherry-pick of upstream bbf9caf996d7: remove the now-unreachable
    K_TICKS_FOREVER guard in cortex_m_systick.

  - **`drivers: timer: cortex_m_systick: derive min timeout from cycle rate`**
    Replace the fixed 1024-cycle MIN_DELAY with a value derived from the actual
    clock rate: `MAX(2, k_us_to_cyc_ceil32(10))`. On 32 kHz platforms this yields
    a 2-cycle floor (~62 µs), well below one tick, while keeping correctness on
    high-frequency cores.

  - **`dts: arm: realtek: bee: drop the systick min-timeout-cycles override`**
    Now that the driver computes the floor automatically, the hand-tuned
    `zephyr,min-timeout-cycles = <32>` override on Bee SoCs is no longer needed.

  ### Kernel timeout / timeslicing correctness

  - **`kernel: timeout: make z_add_timeout round-up conditional on announce`**
    The unconditional +1 tick round-up in `z_add_timeout()` is wrong when called
    from inside `sys_clock_announce_locked()` (already on a tick edge). Make it
    conditional on `announce_remaining == 0` to avoid systematic one-tick drift
    in periodic timers and the slice timer.

  - **`kernel: timeslicing: rearm with slice_size-1 when slicer just fired`**
    After the above fix, `z_time_slice_reset()` must pass `slice_size - 1` when
    `slice_expired[cpu]` is set so the round-up lands the next fire at exactly
    `slice_size` ticks. Other reset paths (voluntary yield, preemption, thread
    creation) keep the full round-up.

  ### Scheduler test improvements

  - **`tests: kernel: switch slice timing tests to tick-quantized measurement`**
    Replace ms/cycle bookkeeping with a `ticks_delta()` helper based on
    `k_uptime_ticks()`, collapsing all bounds to the exact `[SLICE_TICKS,
    SLICE_TICKS+1]` window.

  - **`tests: kernel: sched: document tests and align group naming`**
    Rewrite per-test Doxygen blocks to follow the `@details / Test steps /
    Expected result` template and rename the module to `tests_kernel_sched`.

  - **`tests: kernel: sched: collapse duplicate skip-stub test definitions`**
    Remove duplicate `ZTEST()` registrations by moving `#ifdef` guards inside
    the single function body.

  - **`tests: kernel: sched: time slices with the real cycles per tick`**
    Convert cycle→tick arithmetic to use `k_ticks_to_cyc_floor32(1)` (real
    cycles per tick) instead of the fractional HW/ticks ratio, fixing failures
    on 32768 Hz platforms where `floor(32768 / 1000) = 32`.

  - **`tests: kernel: sched: schedule_api: replace spin_for_ms with k_busy_wait`**
    `spin_for_ms()` polls `k_uptime_get_32()` directly, bypassing
    `CONFIG_ARCH_HAS_CUSTOM_BUSY_WAIT`. On Realtek RTL87x2G (KM4 core) the
    SysTick COUNTFLAG is asserted one cycle early (VAL=1 instead of 0), causing
    `elapsed()` to over-count and `k_uptime_get_32()` to run fast, so
    `spin_for_ms()` exits prematurely and time-slice tests fail. Replacing it
    with `k_busy_wait()` lets the platform's custom busy-wait hook (backed by
    the HAL's own delay routine) be used instead.

  ## Background: RTL87x2G SysTick hardware bug

  The RTL87x2G SoC (KM4 core) has a known SysTick IP errata: COUNTFLAG is
  - **`tests: kernel: sched: schedule_api: replace spin_for_ms with k_busy_wait`**
    `spin_for_ms()` polls `k_uptime_get_32()` directly, bypassing
    `CONFIG_ARCH_HAS_CUSTOM_BUSY_WAIT`. On Realtek RTL87x2G (KM4 core) the
    SysTick COUNTFLAG is asserted one cycle early (VAL=1 instead of 0), causing
    `elapsed()` to over-count and `k_uptime_get_32()` to run fast, so
    `spin_for_ms()` exits prematurely and time-slice tests fail. Replacing it
    with `k_busy_wait()` lets the platform's custom busy-wait hook (backed by
    the HAL's own delay routine) be used instead.

  ## Background: RTL87x2G SysTick hardware bug

  The RTL87x2G SoC (KM4 core) has a known SysTick IP errata: COUNTFLAG is
  asserted when `VAL == 1` rather than when `VAL == 0`. This causes
  `elapsed()` in `cortex_m_systick.c` to increment `overflow_cyc` one cycle
  early, making `k_uptime_get_32()` return a value slightly larger than the
  true elapsed time. The `spin_for_ms()` replacement avoids this code path
  entirely. The underlying driver bug is tracked in BEE4RD-667.
