### PR TITLE
tests: replace hard-coded timing tolerances with clock-derived bounds

### DIFF
--- a/tests/kernel/timer/timer_behavior/Kconfig
+++ b/tests/kernel/timer/timer_behavior/Kconfig
@@ -21,12 +21,6 @@ config TIMER_TEST_PERIOD
 	int "The number of microseconds to for the timer period"
 	default 1000
 
-config TIMER_TEST_MAX_STDDEV
-	int "Maximum standard deviation in microseconds allowed"
-	default 33 if NPCX_ITIM_TIMER
-	default 33 if ITE_IT8XXX2_TIMER
-	default 10
-
 
 config TIMER_EXTERNAL_TEST
 	bool "Perform test using an external tool"

--- a/tests/kernel/timer/timer_behavior/Kconfig
+++ b/tests/kernel/timer/timer_behavior/Kconfig
@@ -27,10 +27,6 @@ config TIMER_TEST_MAX_STDDEV
 	default 33 if ITE_IT8XXX2_TIMER
 	default 10
 
-config TIMER_TEST_MAX_DRIFT
-	int "Maximum drift in microseconds allowed (should be about 1 period allowance)"
-	default 1000
-
 
 config TIMER_EXTERNAL_TEST
 	bool "Perform test using an external tool"

--- a/tests/kernel/timer/timer_behavior/Kconfig
+++ b/tests/kernel/timer/timer_behavior/Kconfig
@@ -31,18 +31,6 @@ config TIMER_TEST_MAX_DRIFT
 	int "Maximum drift in microseconds allowed (should be about 1 period allowance)"
 	default 1000
 
-config TIMER_TEST_PERIOD_MAX_DRIFT_PERCENT
-	int "Maximum drift percentage for the timer period"
-	# Use 13% on nRF platforms using the RTC timer because one tick there is
-	# ~122 us (see SYS_CLOCK_TICKS_PER_SEC configuration above) and one tick
-	# difference in the test period is nothing unusual (it can happen for
-	# example if a new tick elapses right after the kernel gets the number
-	# of elapsed ticks when scheduling a new timeout but before the timer
-	# driver sets up that timeout).
-	default 13 if NRF_RTC_TIMER && TICKLESS_KERNEL
-	default 10
-	help
-	  A value of 10 means 10%.
 
 config TIMER_EXTERNAL_TEST
 	bool "Perform test using an external tool"

--- a/tests/kernel/timer/timer_behavior/README
+++ b/tests/kernel/timer/timer_behavior/README
@@ -68,8 +68,8 @@ the board under test and one at the external tool (Zephyr implementation of
 the timer also plays a role, and it's the real target of the test, but it
 depends on the board's clock). Different clocks run at different speeds, so
 they tend to drift. To be able to account for this drift, the external test
-doesn't reuse CONFIG_TIMER_TEST_MAX_DRIFT and
-CONFIG_TIMER_TEST_PERIOD_MAX_DRIFT_PERCENT, instead introducing
+doesn't reuse CONFIG_TIMER_TEST_MAX_DRIFT or the built-in test's computed
+per-period drift bound, instead introducing
 CONFIG_TIMER_EXTERNAL_TEST_MAX_DRIFT_PPM and
 CONFIG_TIMER_EXTERNAL_TEST_PERIOD_MAX_DRIFT_PPM, that can be more finely tuned
 for the hardware in question.

--- a/tests/kernel/timer/timer_behavior/README
+++ b/tests/kernel/timer/timer_behavior/README
@@ -68,8 +68,7 @@ the board under test and one at the external tool (Zephyr implementation of
 the timer also plays a role, and it's the real target of the test, but it
 depends on the board's clock). Different clocks run at different speeds, so
 they tend to drift. To be able to account for this drift, the external test
-doesn't reuse CONFIG_TIMER_TEST_MAX_DRIFT or the built-in test's computed
-per-period drift bound, instead introducing
+doesn't reuse the built-in test's computed drift bounds, instead introducing
 CONFIG_TIMER_EXTERNAL_TEST_MAX_DRIFT_PPM and
 CONFIG_TIMER_EXTERNAL_TEST_PERIOD_MAX_DRIFT_PPM, that can be more finely tuned
 for the hardware in question.

--- a/tests/kernel/timer/timer_behavior/pytest/test_timer.py
+++ b/tests/kernel/timer/timer_behavior/pytest/test_timer.py
@@ -38,9 +38,9 @@ def do_analysis(test, stats, stats_count, config, sys_clock_hw_cycles_per_sec):
                  expected_period_drift) / 1_000_000
 
     min_cyc = 1. / sys_clock_hw_cycles_per_sec
-    max_stddev = int(config['TIMER_TEST_MAX_STDDEV']) / 1_000_000
-    # Max STDDEV cannot be lower than clock single cycle
-    max_stddev = max(min_cyc, max_stddev)
+    # Allowed jitter is one tick (the scheduling quantum), computed from the
+    # clock; never below a single cycle.
+    max_stddev = max(min_cyc, 1. / ticks_per_sec)
 
     max_drift_ppm = int(config['TIMER_EXTERNAL_TEST_MAX_DRIFT_PPM'])
     time_diff = stats['total_time'] - seconds - expected_total_drift

--- a/tests/kernel/timer/timer_behavior/src/jitter_drift.c
+++ b/tests/kernel/timer/timer_behavior/src/jitter_drift.c
@@ -237,8 +237,10 @@ static void do_test_using(void (*sample_collection_fn)(void), const char *mechan
 		- expected_time_drift_us;
 	double time_diff_us_abs = time_diff_us >= 0.0 ? time_diff_us : -time_diff_us;
 
-	/* If max stddev is lower than a single clock tick then round it up. */
-	uint32_t max_stddev = MAX(k_ticks_to_us_ceil32(1), CONFIG_TIMER_TEST_MAX_STDDEV);
+	/* Allowed jitter is one tick, the scheduling quantum, computed from the
+	 * clock rather than a tuning value.
+	 */
+	uint32_t max_stddev = k_ticks_to_us_ceil32(1);
 
 	TC_PRINT("timer clock rate %u, kernel tick rate %d\n",
 		 sys_clock_hw_cycles_per_sec(), CONFIG_SYS_CLOCK_TICKS_PER_SEC);

--- a/tests/kernel/timer/timer_behavior/src/jitter_drift.c
+++ b/tests/kernel/timer/timer_behavior/src/jitter_drift.c
@@ -363,9 +363,14 @@ static void do_test_using(void (*sample_collection_fn)(void), const char *mechan
 	zassert_true(stddev_us < (double)max_stddev,
 		     "Standard deviation (in microseconds) outside expected bound");
 
-	/* Validate the timer drift (accuracy over time) is within a configurable bound */
-	zassert_true(time_diff_us_abs < CONFIG_TIMER_TEST_MAX_DRIFT,
-		     "Drift (in microseconds) outside expected bound");
+	/* Validate the timer accuracy over time: the total measured time must
+	 * not drift from the model by as much as a whole period. That "within
+	 * one period" allowance is the test period itself, so no separate tuning
+	 * value is needed.
+	 */
+	zassert_true(time_diff_us_abs < test_period,
+		     "Total drift %f us exceeds one period (%f us)",
+		     time_diff_us_abs, test_period);
 }
 
 ZTEST(timer_jitter_drift, test_jitter_drift_timer_period)

--- a/tests/kernel/timer/timer_behavior/src/jitter_drift.c
+++ b/tests/kernel/timer/timer_behavior/src/jitter_drift.c
@@ -311,22 +311,51 @@ static void do_test_using(void (*sample_collection_fn)(void), const char *mechan
 		 max_stddev
 		 );
 
-	/* Validate the maximum/minimum timer period is off by no more than 10% */
+	/* Validate the maximum/minimum timer period is within the allowed drift.
+	 *
+	 * The bound is an absolute time, one tick, computed from the clock rather
+	 * than a percentage of the period. A periodic timer is rescheduled in
+	 * whole ticks, so a single period can land up to one tick from nominal;
+	 * one tick also covers the measurement slop at any realistic tick rate.
+	 * It scales with the cycle-to-tick ratio, so a coarse clock (e.g. a
+	 * 32 kHz SysTick, where a tick is a large fraction of the period) widens
+	 * the bound automatically and needs no per-platform value.
+	 */
 	double test_period = (double)CONFIG_TIMER_TEST_PERIOD;
-	double period_max_drift_percentage =
-		(double)CONFIG_TIMER_TEST_PERIOD_MAX_DRIFT_PERCENT / 100;
-	double min_us_bound = test_period - period_max_drift_percentage * test_period
-		+ expected_period_drift;
-	double max_us_bound = test_period + period_max_drift_percentage * test_period
-		+ expected_period_drift;
+	double allowed_drift_us = (double)k_ticks_to_us_ceil32(1);
+	double nominal_us = test_period + expected_period_drift;
 
-	zassert_true(min_us >= min_us_bound,
-		"Shortest timer period too short (off by more than expected %d%%)",
-		CONFIG_TIMER_TEST_PERIOD_MAX_DRIFT_PERCENT);
-	zassert_true(max_us <= max_us_bound,
-		"Longest timer period too long (off by more than expected %d%%)",
-		CONFIG_TIMER_TEST_PERIOD_MAX_DRIFT_PERCENT);
+	/* Report the measured drift as a percentage for readability; the
+	 * pass/fail decision below is on the absolute allowed_drift_us bound.
+	 */
+	TC_PRINT("period drift allowed +/-%f us (%.3g%%); measured min %f us (%.3g%%), "
+		 "max %f us (%.3g%%)\n",
+		 allowed_drift_us, allowed_drift_us / test_period * 100,
+		 nominal_us - min_us, (nominal_us - min_us) / test_period * 100,
+		 max_us - nominal_us, (max_us - nominal_us) / test_period * 100);
 
+	zassert_true(max_us <= nominal_us + allowed_drift_us,
+		"Longest timer period %f us too long: drift %f us (%.3g%%) exceeds allowed %f us",
+		max_us, max_us - nominal_us, (max_us - nominal_us) / test_period * 100,
+		allowed_drift_us);
+
+	/* The low-side bound (nominal - one tick) only carries information while
+	 * the nominal period stays above one tick. A period can never be
+	 * negative, so once the period is within a tick of zero, "one tick short"
+	 * permits an arbitrarily short period and the assertion can no longer
+	 * fail. Skip it there rather than run a check that always passes; at that
+	 * resolution the short side is constrained by the jitter (stddev) and
+	 * total-drift checks below.
+	 */
+	if (nominal_us > allowed_drift_us) {
+		zassert_true(min_us >= nominal_us - allowed_drift_us,
+			"Shortest timer period %f us too short: drift %f us (%.3g%%) exceeds allowed %f us",
+			min_us, nominal_us - min_us, (nominal_us - min_us) / test_period * 100,
+			allowed_drift_us);
+	} else {
+		TC_PRINT("nominal period (%f us) is within one tick; short-side bound "
+			 "not applicable, see stddev and total drift\n", nominal_us);
+	}
 
 	/* Validate the timer deviation (precision/jitter of the timer) is within a configurable
 	 * bound

--- a/tests/kernel/usage/thread_runtime_stats/src/test_thread_runtime_stats.c
+++ b/tests/kernel/usage/thread_runtime_stats/src/test_thread_runtime_stats.c
@@ -8,21 +8,6 @@
 
 #define HELPER_STACK_SIZE 500
 
-/**
- * @brief Verify @a va1 and @a val2 are within @a pcnt % of each other
- */
-#define TEST_WITHIN_X_PERCENT(val1, val2, pcnt)                       \
-	((((val1) * 100) < ((val2) * (100 + (pcnt)))) &&              \
-	 (((val1) * 100) > ((val2) * (100 - (pcnt))))) ? true : false
-
-#if defined(CONFIG_RISCV)
-#define IDLE_EVENT_STATS_PRECISION 7
-#elif defined(CONFIG_QEMU_TARGET)
-#define IDLE_EVENT_STATS_PRECISION 3
-#else
-#define IDLE_EVENT_STATS_PRECISION 1
-#endif
-
 static struct k_thread helper_thread;
 static K_THREAD_STACK_DEFINE(helper_stack, HELPER_STACK_SIZE);
 
@@ -87,11 +72,7 @@ ZTEST(usage_api, test_all_stats_usage)
 
 	k_thread_runtime_stats_all_get(&stats2);
 
-#if defined(CONFIG_RISCV)
-	k_sleep(K_TICKS(3));  /* Helper runs for 3 ticks - on slower platforms */
-#else
-	k_sleep(K_TICKS(2));  /* Helper runs for 2 ticks */
-#endif
+	k_sleep(K_TICKS(3));  /* Helper runs for 3 ticks */
 
 	k_thread_runtime_stats_all_get(&stats3);
 
@@ -181,8 +162,13 @@ ZTEST(usage_api, test_all_stats_usage)
 	zassert_true(stats4.current_cycles <= stats1.current_cycles);
 	zassert_true(stats5.current_cycles > stats4.current_cycles);
 
-	zassert_true(TEST_WITHIN_X_PERCENT(stats4.peak_cycles,
-					   stats3.peak_cycles, IDLE_EVENT_STATS_PRECISION), NULL);
+	/* The peak busy stretch is the same one before and after it closed; it
+	 * only grew by the sub-tick measurement tail between the stats3 sample
+	 * and the idle event. Scheduling here is tick aligned, so comparing in
+	 * the tick domain makes that tail vanish, no percentage tolerance needed.
+	 */
+	zassert_equal(k_cyc_to_ticks_near64(stats4.peak_cycles),
+		      k_cyc_to_ticks_near64(stats3.peak_cycles), NULL);
 	zassert_true(stats4.peak_cycles == stats5.peak_cycles);
 
 	zassert_true(stats4.average_cycles > 0);


### PR DESCRIPTION

  Three kernel timing tests used hard-coded tolerance values with per-platform
  exceptions to accommodate platforms with coarse clocks (e.g. a 32 kHz SysTick).
  This series replaces all of them with bounds computed directly from the clock,
  so no per-platform tuning is needed when new coarse-clock platforms are added.

  tests/kernel/timer/timer_behavior (3 commits, zephyrproject-rtos/zephyr#113053):

  - Per-period drift was a hand-tuned percentage (TIMER_TEST_PERIOD_MAX_DRIFT_PERCENT,
  default 10%, 13% for nRF RTC). Replaced by one tick (k_ticks_to_us_ceil32(1)):
  a periodic timer is rescheduled in whole ticks, so a single period can land at
  most one tick from nominal. The bound scales automatically with the tick period,
  so coarse clocks widen it without any per-platform override. The Kconfig symbol
  is dropped.
  - Total drift was TIMER_TEST_MAX_DRIFT hard-coded at 1000 µs — which its own
  help text noted was "about 1 period allowance". Replaced by the test period
  directly; the Kconfig symbol is dropped.
  - Jitter (stddev) was TIMER_TEST_MAX_STDDEV (10 µs, 33 µs for NPCX/ITE).
  The check already floored the bound at one tick, and one tick exceeds those
  values on every platform that runs this test, making the configured values dead.
  Use one tick directly and drop the Kconfig symbol and its per-platform overrides.

  tests/kernel/usage/thread_runtime_stats (1 commit, zephyrproject-rtos/zephyr#113075):

  test_all_stats_usage compared two peak_cycles samples with a percentage
  tolerance (IDLE_EVENT_STATS_PRECISION, 1% default, 3% QEMU, 7% RISC-V).
  The two samples span the same busy stretch; their difference is only a sub-tick
  tail that is negligible on fast clocks but several percent on a coarse clock.
  Switching to the tick domain with k_cyc_to_ticks_near64() makes the tail round
  away, both samples land on the same tick, and no tolerance or per-platform value
  is needed. TEST_WITHIN_X_PERCENT and IDLE_EVENT_STATS_PRECISION are dropped,
  along with the CONFIG_RISCV special-case sleep.