### PR TITLE
soc: realtek: rtl8752h: remove custom arch_busy_wait

### DIFF
--- a/soc/realtek/bee/rtl8752h/Kconfig.defconfig.series
+++ b/soc/realtek/bee/rtl8752h/Kconfig.defconfig.series
@@ -18,9 +18,6 @@ config SYS_CLOCK_TICKS_PER_SEC
 config TIMESLICE_SIZE
 	default 10
 
-config ARCH_HAS_CUSTOM_BUSY_WAIT
-	default y
-
 if BT
 
 config NUM_METAIRQ_PRIORITIES

--- a/soc/realtek/bee/rtl8752h/soc.c
+++ b/soc/realtek/bee/rtl8752h/soc.c
@@ -15,7 +15,6 @@
 #include "rom_uuid.h"
 #include "rtl_boot_record.h"
 #include "system_rtl876x.h"
-#include "utils.h"
 #include "vector_table.h"
 
 extern void _isr_wrapper(void);
@@ -163,10 +162,3 @@ void soc_late_init_hook(void)
 
 	rtl_boot_stage_record(PON_BOOT_DONE);
 }
-
-#ifdef CONFIG_ARCH_HAS_CUSTOM_BUSY_WAIT
-void arch_busy_wait(uint32_t usec_to_wait)
-{
-	platform_delay_us(usec_to_wait);
-}
-#endif


### PR DESCRIPTION
The rtl8752h (CM0+) SysTick does not have the COUNTFLAG early-assertion
hardware bug present on the KM4 core (rtl87x2g), so the default
`k_busy_wait()` implementation works correctly on this platform.

The previous custom `arch_busy_wait()` was a NOP-loop calibrated for a
specific optimization level. It terminates one tick too early, causing
`test_slice_scheduling` to fail with `tick_delta=199` (expected ~200)
when the test suite uses `k_busy_wait()` instead of the uptime-polling
`spin_for_ms()` (upstream PR zephyrproject-rtos/zephyr#113550).

Remove `ARCH_HAS_CUSTOM_BUSY_WAIT` and its `arch_busy_wait()`
implementation to fall back to the default `k_busy_wait()`, which gives
reliable results on this platform.

Tested on rtl8752h with `tests/kernel/sched/schedule_api`: all slice
timing tests pass after this change.

Upstream PR: zephyrproject-rtos/zephyr#113581