### PR TITLE
boards: realtek: fix board yaml ram fields and resize rtl87x2g TCM split

### DIFF
--- a/boards/realtek/rtl8752h_evb/rtl8752h_evb_rtl8752hjf.yaml
+++ b/boards/realtek/rtl8752h_evb/rtl8752h_evb_rtl8752hjf.yaml
@@ -2,7 +2,7 @@ identifier: rtl8752h_evb/rtl8752hjf
 name: RTL8752H-EVB-RTL8752HJF
 type: mcu
 arch: arm
-ram: 70
+ram: 57
 flash: 924
 toolchain:
   - zephyr

--- a/boards/realtek/rtl8752h_evb/rtl8752h_evb_rtl8752hjl.yaml
+++ b/boards/realtek/rtl8752h_evb/rtl8752h_evb_rtl8752hjl.yaml
@@ -2,7 +2,7 @@ identifier: rtl8752h_evb/rtl8752hjl
 name: RTL8752H-EVB-RTL8752HJL
 type: mcu
 arch: arm
-ram: 70
+ram: 57
 flash: 412
 toolchain:
   - zephyr

--- a/boards/realtek/rtl8752h_evb/rtl8752h_evb_rtl8752hkf.yaml
+++ b/boards/realtek/rtl8752h_evb/rtl8752h_evb_rtl8752hkf.yaml
@@ -2,7 +2,7 @@ identifier: rtl8752h_evb/rtl8752hkf
 name: RTL8752H-EVB-RTL8752HKF
 type: mcu
 arch: arm
-ram: 70
+ram: 57
 flash: 924
 toolchain:
   - zephyr

--- a/boards/realtek/rtl8752h_evb/rtl8752h_evb_rtl8752hmf.yaml
+++ b/boards/realtek/rtl8752h_evb/rtl8752h_evb_rtl8752hmf.yaml
@@ -2,7 +2,7 @@ identifier: rtl8752h_evb/rtl8752hmf
 name: RTL8752H-EVB-RTL8752HMF
 type: mcu
 arch: arm
-ram: 70
+ram: 57
 flash: 412
 toolchain:
   - zephyr

--- a/boards/realtek/rtl87x2g_evb_a/rtl87x2g_evb_a_rtl8762gkh.yaml
+++ b/boards/realtek/rtl87x2g_evb_a/rtl87x2g_evb_a_rtl8762gkh.yaml
@@ -2,7 +2,7 @@ identifier: rtl87x2g_evb_a/rtl8762gkh
 name: RTL87x2G Model A Evaluation Board with RTL8762GKH Daughter Board
 type: mcu
 arch: arm
-ram: 384
+ram: 176
 flash: 828
 toolchain:
   - zephyr

--- a/boards/realtek/rtl87x2g_evb_a/rtl87x2g_evb_a_rtl8762gku.yaml
+++ b/boards/realtek/rtl87x2g_evb_a/rtl87x2g_evb_a_rtl8762gku.yaml
@@ -2,7 +2,7 @@ identifier: rtl87x2g_evb_a/rtl8762gku
 name: RTL87x2G Model A Evaluation Board with RTL8762GKU Daughter Board
 type: mcu
 arch: arm
-ram: 384
+ram: 176
 flash: 828
 toolchain:
   - zephyr

--- a/boards/realtek/rtl87x2g_evb_a/rtl87x2g_evb_a_rtl8762grh.yaml
+++ b/boards/realtek/rtl87x2g_evb_a/rtl87x2g_evb_a_rtl8762grh.yaml
@@ -2,7 +2,7 @@ identifier: rtl87x2g_evb_a/rtl8762grh
 name: RTL87x2G Model A Evaluation Board with RTL8762GRH Daughter Board
 type: mcu
 arch: arm
-ram: 384
+ram: 176
 flash: 316
 toolchain:
   - zephyr

--- a/boards/realtek/rtl87x2g_evb_a/rtl87x2g_evb_a_rtl8762gru.yaml
+++ b/boards/realtek/rtl87x2g_evb_a/rtl87x2g_evb_a_rtl8762gru.yaml
@@ -2,7 +2,7 @@ identifier: rtl87x2g_evb_a/rtl8762gru
 name: RTL87x2G Model A Evaluation Board with RTL8762GRU Daughter Board
 type: mcu
 arch: arm
-ram: 384
+ram: 176
 flash: 316
 toolchain:
   - zephyr

--- a/dts/arm/realtek/bee/rtl87x2g.dtsi
+++ b/dts/arm/realtek/bee/rtl87x2g.dtsi
@@ -60,16 +60,16 @@
 			reg = <0x100000 DT_SIZE_K(3)>;
 		};
 
-		/* 0x100c00-0x13cc00: Free space for Zephyr */
+		/* 0x100c00-0x133c00: Free space for Zephyr */
 		tcm0: memory@100c00 {
 			/* TCM0, used as zephyr-sram */
-			reg = <0x100c00 DT_SIZE_K(100)>;
+			reg = <0x100c00 DT_SIZE_K(176)>;
 		};
 
-		tcm1: memory@119c00 {
+		tcm1: memory@12cc00 {
 			/* TCM1, used as zephyr-itcm */
 			compatible = "zephyr,memory-region", "arm,itcm";
-			reg = <0x119c00 DT_SIZE_K(104)>;
+			reg = <0x12cc00 DT_SIZE_K(28)>;
 			zephyr,memory-region = "ITCM";
 		};
 


### PR DESCRIPTION
## Summary

Fix inaccurate `ram` fields in board yaml files and resize the
rtl87x2g TCM split to give Zephyr more usable SRAM.

## Changes

### rtl87x2g: resize TCM split to 176K SRAM / 28K ITCM

rtl87x2g exposes 204 KB of TCM to Zephyr (0x100c00–0x133c00).
The previous 100 KB / 104 KB split left ITCM 101 KB idle (actual
usage is ~2.2 KB of reloc tables), while applications such as the
CMSIS-DSP `matrix.binary_q15` test require ≥144 KB of SRAM and
fail with OOM.

New boundary:
- `tcm0` (zephyr,sram): 0x100c00 + **176 KB** → 0x12cc00
- `tcm1` (zephyr,itcm): 0x12cc00 + **28 KB** → 0x133c00

Board yaml `ram` updated from the stale placeholder 384 to **176**
for all four variants (gkh, gku, grh, gru).

### rtl8752h_evb: fix ram field to 57 KB

`zephyr,sram` points to `data_ram_app_0` which is `DT_SIZE_K(57)`.
The previous value of 70 was inaccurate; corrected for all four
variants (hjf, hjl, hkf, hmf).

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)