### PR TITLE
soc: realtek: rtl87x2g: restore z_arm_nmi after SoC init

### DIFF
--- a/soc/realtek/bee/rtl87x2g/soc.c
+++ b/soc/realtek/bee/rtl87x2g/soc.c
@@ -31,6 +31,7 @@ extern char __extram_data_load_start[];
 extern char __extram_bss_start[];
 extern char __extram_bss_end[];
 
+extern void z_arm_nmi(void);
 extern void _isr_wrapper(void);
 extern void Peripheral_Handler(void);
 
@@ -125,6 +126,8 @@ static void rtl87x2g_isr_register(void)
 			}
 		}
 	}
+
+	RamVectorTableUpdate(NMI_VECTORn, (IRQ_Fun)z_arm_nmi);
 
 	irq_unlock(key);
 }


### PR DESCRIPTION
## Problem

\`tests/arch/arm/arm_runtime_nmi\` fails on \`rtl87x2g_evb_a/rtl8762gku\`:

The RTL87x2G ROM initialization routines (e.g. \`phy_init\`) call
\`RamVectorTableUpdate()\` internally to install RTK-specific handlers
into the RAM vector table.  One of these overwrites the NMI vector
(entry 2) with an RTK handler, replacing Zephyr's \`z_arm_nmi\`.
Because the Zephyr test exercises the NMI path directly, it never
reaches Zephyr's handler and fails.

## Root Cause

\`soc_early_init_hook\` relocates VTOR to a RAM buffer so that ROM code
can write to the vector table without faulting (see the Phase 1 / Phase
2 comment block in \`soc.c\`).  Phase 2 (\`rtl87x2g_isr_register\`) already
reconciles all peripheral IRQ vectors by detecting ROM-installed
handlers and re-routing them through \`_isr_wrapper\`.  However, the NMI
vector (which sits in the System Exception area below IRQ 0) was not
covered by this loop, leaving the RTK NMI handler in place after init.

## Fix

Add a single \`RamVectorTableUpdate(NMI_VECTORn, z_arm_nmi)\` call at the
end of \`rtl87x2g_isr_register()\`, which runs in \`soc_late_init_hook\`
after all SoC initialization is complete.  This restores the NMI vector
to Zephyr's handler, consistent with how peripheral IRQ vectors are
already reconciled in the same function.

## Testing

\`tests/arch/arm/arm_runtime_nmi\` now passes on
\`rtl87x2g_evb_a/rtl8762gku\`.

Cherry-picked from upstream zephyrproject-rtos/zephyr#113646

🤖 Generated with [Claude Code](https://claude.com/claude-code)