### PR TITLE
tests: arch: ARM tests should run only on arm arch

### DIFF
--- a/tests/arch/arm/arm_irq_advanced_features/testcase.yaml
+++ b/tests/arch/arm/arm_irq_advanced_features/testcase.yaml
@@ -3,7 +3,8 @@ common:
   tags:
     - arm
     - interrupt
-  arch_allow: arm
+  arch_allow:
+    - arm
 tests:
   arch.arm.irq_advanced_features:
     filter: not CONFIG_TRUSTED_EXECUTION_NONSECURE

--- a/tests/arch/arm/arm_mpu_pxn/testcase.yaml
+++ b/tests/arch/arm/arm_mpu_pxn/testcase.yaml
@@ -1,5 +1,7 @@
 common:
   filter: CONFIG_ARM_MPU_PXN
+  arch_allow:
+    - arm
   tags:
     - arm
     - mpu

--- a/tests/arch/arm/arm_pacbti/testcase.yaml
+++ b/tests/arch/arm/arm_pacbti/testcase.yaml
@@ -1,6 +1,8 @@
 common:
   tags:
     - arm
+  arch_allow:
+    - arm
   platform_allow:
     - mps3/corstone310/fvp
     - mps3/corstone310/fvp/ns

--- a/tests/arch/arm/arm_user_stack_test/testcase.yaml
+++ b/tests/arch/arm/arm_user_stack_test/testcase.yaml
@@ -1,5 +1,7 @@
 common:
   tags:
+    - arm_user_stack
+  arch_allow:
     - arm
   timeout: 120
   # TODO: remove the platform_exclude once the MPS2 issue is fixed

--- a/tests/arch/arm64/arm64_pacbti/testcase.yaml
+++ b/tests/arch/arm64/arm64_pacbti/testcase.yaml
@@ -5,6 +5,8 @@ common:
     - security
   timeout: 30
   filter: CONFIG_ARMV9_A
+  arch_allow:
+    - arm64
 tests:
   arch.arm64.pacbti:
     integration_platforms:


### PR DESCRIPTION
Backport of upstream commit [1640d4b](https://github.com/zephyrproject-rtos/zephyr/commit/1640d4b08053a866c8071d03db88a03276899632).

## Summary

Use `arch_allow` to restrict ARM/ARM64 architecture tests to only run on the respective arch, preventing them from being picked up by non-ARM targets.

**Files changed:**
- `tests/arch/arm/arm_irq_advanced_features/testcase.yaml`
- `tests/arch/arm/arm_mpu_pxn/testcase.yaml`
- `tests/arch/arm/arm_pacbti/testcase.yaml`
- `tests/arch/arm/arm_user_stack_test/testcase.yaml`
- `tests/arch/arm64/arm64_pacbti/testcase.yaml`

🤖 Generated with [Claude Code](https://claude.com/claude-code)