### PR TITLE
tests: arch: arm: fix filter logic grouping for sw_vector_relay

### DIFF
--- a/tests/arch/arm/arm_sw_vector_relay/testcase.yaml
+++ b/tests/arch/arm/arm_sw_vector_relay/testcase.yaml
@@ -1,6 +1,6 @@
 tests:
   arch.arm.sw_vector_relay:
-    filter: CONFIG_ARMV6_M_ARMV8_M_BASELINE or CONFIG_ARMV7_M_ARMV8_M_MAINLINE
+    filter: (CONFIG_ARMV6_M_ARMV8_M_BASELINE or CONFIG_ARMV7_M_ARMV8_M_MAINLINE)
           and not CONFIG_SOC_SERIES_RTL87X2G and not CONFIG_SOC_SERIES_RTL8752H
     tags:
       - vector_relay
@@ -8,7 +8,7 @@ tests:
     integration_platforms:
       - mps2/an385
   arch.arm.sw_vector_relay.sram_vector_table:
-    filter: CONFIG_ARMV6_M_ARMV8_M_BASELINE or CONFIG_ARMV7_M_ARMV8_M_MAINLINE
+    filter: (CONFIG_ARMV6_M_ARMV8_M_BASELINE or CONFIG_ARMV7_M_ARMV8_M_MAINLINE)
           and not CONFIG_SOC_SERIES_RTL87X2G and not CONFIG_SOC_SERIES_RTL8752H
     tags:
       - vector_relay


### PR DESCRIPTION
Add parentheses around ARMV6/ARMV7 OR expressions to ensure correct
precedence when combined with 'and not' SOC filters.