### PR TITLE
soc: realtek: bee: remove TIMESLICE_SIZE default

### DIFF
--- a/samples/subsys/tracing/boards/rtl87x2j_evb_rtl8762jth.conf
+++ b/samples/subsys/tracing/boards/rtl87x2j_evb_rtl8762jth.conf
@@ -1,8 +1,0 @@
-# Increase timeslice size to avoid tracing UART output consuming the entire
-# timeslice before application code gets a chance to run. At 115200 baud,
-# after the sys timer ISR resets the timeslice, three trace hooks fire
-# sequentially (isr_exit, switched_out, switched_in), each taking ~3-4ms
-# of synchronous UART output, totalling ~9-12ms. This exceeds the default
-# 10ms timeslice, leaving no CPU time for application code to run.
-# Setting to 30ms provides sufficient headroom.
-CONFIG_TIMESLICE_SIZE=30

--- a/samples/subsys/tracing/sample.yaml
+++ b/samples/subsys/tracing/sample.yaml
@@ -12,7 +12,6 @@ tests:
   sample.tracing.user:
     extra_args:
       - CONF_FILE="prj_user.conf"
-      - platform:rtl87x2j_evb/rtl8762jth:EXTRA_CONF_FILE="boards/rtl87x2j_evb_rtl8762jth.conf"
     integration_platforms:
       - qemu_x86
     platform_exclude:
@@ -91,6 +90,5 @@ tests:
     extra_args:
       - CONF_FILE="prj_gpio.conf"
       - EXTRA_DTC_OVERLAY_FILE="gpio.overlay"
-      - platform:rtl87x2j_evb/rtl8762jth:EXTRA_CONF_FILE="boards/rtl87x2j_evb_rtl8762jth.conf"
     integration_platforms:
       - native_sim

--- a/soc/realtek/bee/rtl8752h/Kconfig.defconfig.series
+++ b/soc/realtek/bee/rtl8752h/Kconfig.defconfig.series
@@ -15,9 +15,6 @@ config SYS_CLOCK_HW_CYCLES_PER_SEC
 config SYS_CLOCK_TICKS_PER_SEC
 	default 1000
 
-config TIMESLICE_SIZE
-	default 10
-
 if BT
 
 config NUM_METAIRQ_PRIORITIES

--- a/soc/realtek/bee/rtl87x2g/Kconfig.defconfig.series
+++ b/soc/realtek/bee/rtl87x2g/Kconfig.defconfig.series
@@ -21,9 +21,6 @@ config SYS_CLOCK_TICKS_PER_SEC
 config ARCH_HAS_CUSTOM_BUSY_WAIT
 	default y
 
-config TIMESLICE_SIZE
-	default 10
-
 config INIT_STACKS
 	default y
 

--- a/soc/realtek/bee/rtl87x2j/Kconfig.defconfig.series
+++ b/soc/realtek/bee/rtl87x2j/Kconfig.defconfig.series
@@ -29,9 +29,6 @@ config SYS_CLOCK_HW_CYCLES_PER_SEC
 config TICKLESS_KERNEL
 	default y
 
-config TIMESLICE_SIZE
-	default 10
-
 config INIT_STACKS
 	default y
 


### PR DESCRIPTION
## Summary

Remove the per-SoC `TIMESLICE_SIZE` defaults (10 ms) from `rtl87x2g`, `rtl87x2j`, and `rtl8752h` Kconfig.defconfig.series. The Zephyr scheduler already provides this value as a Kconfig default; overriding it at the SoC level is unnecessary.

As a follow-up, remove the `rtl87x2j_evb` tracing workaround that bumped `TIMESLICE_SIZE` to 30 ms — it was only needed to compensate for the SoC-level default, and is no longer required.

## Changes

- `soc/realtek/bee/rtl87x2g/Kconfig.defconfig.series`: remove `TIMESLICE_SIZE default 10`
- `soc/realtek/bee/rtl87x2j/Kconfig.defconfig.series`: remove `TIMESLICE_SIZE default 10`
- `soc/realtek/bee/rtl8752h/Kconfig.defconfig.series`: remove `TIMESLICE_SIZE default 10`
- `samples/subsys/tracing/boards/rtl87x2j_evb_rtl8762jth.conf`: delete (no longer needed)
- `samples/subsys/tracing/sample.yaml`: remove `rtl87x2j_evb` board-specific conf file references

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)