### PR TITLE
kernel: backport timer jitter drift fixes

### DIFF
--- a/drivers/timer/cortex_m_systick.c
+++ b/drivers/timer/cortex_m_systick.c
@@ -33,10 +33,8 @@ extern unsigned int z_clock_hw_cycles_per_sec;
 #endif
 #endif
 
-/* add MAX_TICKS protection */
-#define _MAX_TICKS (int)((k_ticks_t)(COUNTER_MAX / CYC_PER_TICK) - 1)
-#define MAX_TICKS ((_MAX_TICKS > 0) ? _MAX_TICKS : 1)
-#define MAX_CYCLES (MAX_TICKS * CYC_PER_TICK)
+/* Largest delta we can program into the 24-bit LOAD register. */
+#define MAX_CYCLES ((uint32_t)COUNTER_MAX)
 
 /* Minimum reload the driver will program, i.e. the closest-in timeout it can
  * schedule. Two floors apply.
@@ -104,8 +102,10 @@ static uint32_t min_delay;
 
 #ifdef CONFIG_CORTEX_M_SYSTICK_64BIT_CYCLE_COUNTER
 typedef uint64_t cycle_t;
+typedef int64_t cycle_diff_t;
 #else
 typedef uint32_t cycle_t;
+typedef int32_t cycle_diff_t;
 #endif
 
 /*
@@ -131,6 +131,14 @@ static cycle_t cycle_count;
  * dividing it by CYC_PER_TICK.
  */
 static cycle_t announced_cycles;
+
+/*
+ * Ticks reported to the kernel via sys_clock_elapsed() since the last
+ * announce. Reset in sys_clock_isr() / sys_clock_idle_exit() after an
+ * announce. Used by sys_clock_set_timeout() to compute a tick-aligned
+ * absolute deadline relative to announced_cycles.
+ */
+static uint32_t last_elapsed;
 
 /*
  * This local variable holds the amount of elapsed HW cycles due to
@@ -447,6 +455,7 @@ __attribute__((interrupt("IRQ"))) void sys_clock_isr(void)
 		dcycles = cycle_count - announced_cycles;
 		dticks = dcycles / CYC_PER_TICK;
 		announced_cycles += dticks * CYC_PER_TICK;
+		last_elapsed = 0U;
 		sys_clock_announce(dticks);
 	} else {
 		sys_clock_announce(1);
@@ -523,68 +532,107 @@ void sys_clock_set_timeout(int32_t ticks, bool idle)
 #endif /* !CONFIG_SYSTEM_TIMER_LPM_COMPANION_NONE */
 
 #if defined(CONFIG_TICKLESS_KERNEL)
-	uint32_t delay;
-	uint32_t val1, val2;
-	uint32_t last_load_ = last_load;
-
-	ticks = (ticks == K_TICKS_FOREVER) ? MAX_TICKS : ticks;
-	ticks = CLAMP(ticks - 1, 0, (int32_t)MAX_TICKS);
-
 	k_spinlock_key_t key = k_spin_lock(&lock);
 
+	/*
+	 * Sync cycle_count with current HW state, capturing any wrap that
+	 * might have occurred since the last sync point. The kernel's
+	 * preceding sys_clock_elapsed() call (or the ISR entry sync)
+	 * usually makes this redundant, but we still need to read CTRL
+	 * here to catch any wrap before writing VAL=0 destroys COUNTFLAG.
+	 *
+	 * val1 must be sampled immediately after elapsed() returns, before
+	 * the cycle_count/overflow_cyc writes below, so the window measured
+	 * by (val1 - val2) at the bottom of this function abuts the window
+	 * already accounted for by elapsed() with no gap in between. Any
+	 * instruction inserted between these two lines would be cycles that
+	 * are neither in elapsed()'s return value nor captured by the
+	 * val1/val2 drift compensation, i.e. systematically lost drift.
+	 */
 	uint32_t pending = elapsed();
-
-	val1 = SysTick->VAL;
+	uint32_t val1 = SysTick->VAL;
+	uint32_t old_load = last_load;
 
 	cycle_count += pending;
 	overflow_cyc = 0U;
 
-	uint32_t unannounced = cycle_count - announced_cycles;
+	uint32_t cycles;
 
-	if ((int32_t)unannounced < 0) {
-		/* We haven't announced for more than half the 32-bit
-		 * wrap duration, because new timeouts keep being set
-		 * before the existing one fires.  Force an announce
-		 * to avoid loss of a wrap event, making sure the
-		 * delay is at least the minimum delay possible.
+	cycle_diff_t unannounced = cycle_count - announced_cycles;
+
+	if (ticks == K_TICKS_FOREVER) {
+		/* Schedule as far out as SysTick can go in one LOAD. */
+		cycles = MAX_CYCLES;
+	} else if (unannounced < 0) {
+		/*
+		 * cycle_count has overtaken announced_cycles by more than half
+		 * the cycle_diff_t range. This is reachable when the ISR is
+		 * starved (e.g. a long-running higher-priority IRQ holds the
+		 * CPU) while sys_clock_set_timeout() keeps growing cycle_count
+		 * call after call. Force a near-immediate fire so the ISR can
+		 * drain the backlog before the gap wraps past the unsigned
+		 * range and we start losing cycles permanently. In the 64-bit
+		 * cycle_t configuration this branch is statically unreachable.
 		 */
-		last_load = min_delay;
+		cycles = min_delay;
 	} else {
-		/* Desired delay in the future */
-		delay = ticks * CYC_PER_TICK;
+		/*
+		 * Compute the number of cycles from 'now' to a tick-aligned
+		 * deadline measured from the last announce. last_elapsed is
+		 * the tick count most recently reported to the kernel via
+		 * sys_clock_elapsed(); the kernel's 'ticks' argument is
+		 * measured from that report. 64-bit math absorbs arbitrarily
+		 * large 'ticks' without overflowing the intermediate product.
+		 */
+		int64_t want = ((uint64_t)last_elapsed + ticks) * CYC_PER_TICK;
+		int64_t delta_64 = want - unannounced;
 
-		/* Round delay up to next tick boundary */
-		delay += unannounced;
-		delay = DIV_ROUND_UP(delay, CYC_PER_TICK) * CYC_PER_TICK;
-		delay -= unannounced;
-		delay = MAX(delay, min_delay);
-		if (delay > MAX_CYCLES) {
-			last_load = MAX_CYCLES;
-		} else {
-			last_load = delay;
-		}
+		/*
+		 * Clamp to [min_delay, MAX_CYCLES] so the programmed LOAD is
+		 * within SysTick's 24-bit range and leaves enough cycles to
+		 * reliably service the next ISR. A past-deadline request
+		 * (delta_64 <= 0) is pulled up to min_delay to fire ASAP.
+		 */
+		cycles = CLAMP(delta_64, (int64_t)min_delay, (int64_t)MAX_CYCLES);
 	}
-
-	val2 = SysTick->VAL;
-
-	SysTick->LOAD = last_load - 1;
-	SysTick->VAL = 0; /* resets timer to last_load */
 
 	/*
-	 * Add elapsed cycles while computing the new load to cycle_count.
+	 * val2 must be sampled while the OLD LOAD is still the reload source:
+	 * if a wrap happened between SysTick->LOAD being reprogrammed and the
+	 * val2 read, VAL would reload from the NEW LOAD and the drift-comp
+	 * formula below (which uses old_load for the wrap case) would be
+	 * wrong. Updating last_load (a software shadow) is HW-inert and safe
+	 * to do before val2.
 	 *
-	 * Note that comparing val1 and val2 is normally not good enough to
-	 * guess if the counter wrapped during this interval. Indeed if val1 is
-	 * close to LOAD, then there are little chances to catch val2 between
-	 * val1 and LOAD after a wrap. COUNTFLAG should be checked in addition.
-	 * But since the load computation is faster than MIN_DELAY, then we
-	 * don't need to worry about this case.
+	 * COUNTFLAG is not checked here: the caller guarantees this runs
+	 * faster than MIN_DELAY cycles, so a wrap cannot be missed.
 	 */
+	last_load = cycles;
+
+	uint32_t val2 = SysTick->VAL;
+
+	SysTick->LOAD = cycles - 1U;
+	SysTick->VAL = 0U;	/* resets counter, clears COUNTFLAG */
+
+	/*
+	 * Clear any pending SysTick exception from the old schedule.
+	 * Writing VAL=0 clears COUNTFLAG in CTRL but not ICSR.PENDSTSET,
+	 * so without this a wrap that fired just before the reprogram
+	 * would still trigger the ISR once interrupts are re-enabled.
+	 * On Armv8-M, preserve STTNS (R/W) while writing the W1C bit.
+	 */
+#ifdef SCB_ICSR_STTNS_Msk
+	SCB->ICSR = (SCB->ICSR & SCB_ICSR_STTNS_Msk) | SCB_ICSR_PENDSTCLR_Msk;
+#else
+	SCB->ICSR = SCB_ICSR_PENDSTCLR_Msk;
+#endif
+
 	if (val1 < val2) {
-		cycle_count += (val1 + (last_load_ - val2));
+		cycle_count += val1 + (old_load - val2);
 	} else {
-		cycle_count += (val1 - val2);
+		cycle_count += val1 - val2;
 	}
+
 	k_spin_unlock(&lock, key);
 #endif
 }
@@ -598,9 +646,11 @@ uint32_t sys_clock_elapsed(void)
 	k_spinlock_key_t key = k_spin_lock(&lock);
 	uint32_t unannounced = cycle_count - announced_cycles;
 	uint32_t cyc = elapsed() + unannounced;
+	uint32_t dticks = cyc / CYC_PER_TICK;
 
+	last_elapsed = dticks;
 	k_spin_unlock(&lock, key);
-	return cyc / CYC_PER_TICK;
+	return dticks;
 }
 
 uint32_t sys_clock_cycle_get_32(void)
@@ -675,6 +725,7 @@ void sys_clock_idle_exit(void)
 		dcycles = cycle_count + elapsed() - announced_cycles;
 		dticks = dcycles / CYC_PER_TICK;
 		announced_cycles += dticks * CYC_PER_TICK;
+		last_elapsed = 0U;
 		sys_clock_announce(dticks);
 
 		/* We've already performed all needed operations */

--- a/kernel/timeout.c
+++ b/kernel/timeout.c
@@ -108,7 +108,23 @@ k_ticks_t z_add_timeout(struct _timeout *to, _timeout_func_t fn, k_timeout_t tim
 		if (Z_IS_TIMEOUT_RELATIVE(timeout)) {
 			ticks_elapsed = elapsed();
 			has_elapsed = true;
-			to->dticks = timeout.ticks + 1 + ticks_elapsed;
+			/*
+			 * In the general case, "now" may be anywhere within
+			 * the current tick. Rounding up by one tick guarantees
+			 * "at least N ticks" semantics -- otherwise a request
+			 * made partway through a tick would fire on the next
+			 * tick edge, yielding less than N full ticks.
+			 *
+			 * The one moment we know we are at (or very close to)
+			 * a tick edge is while processing timeouts inside
+			 * sys_clock_announce_locked(), flagged by
+			 * announce_remaining != 0. Periodic timers rely on
+			 * this when rescheduling themselves from the timer
+			 * ISR: the round-up would otherwise accumulate and
+			 * make every period one tick late.
+			 */
+			to->dticks = timeout.ticks + ticks_elapsed +
+				     ((announce_remaining == 0) ? 1 : 0);
 			ticks = curr_tick + to->dticks;
 		} else {
 			k_ticks_t dticks = Z_TICK_ABS(timeout.ticks) - curr_tick;

--- a/kernel/timeout.c
+++ b/kernel/timeout.c
@@ -252,21 +252,29 @@ void sys_clock_announce_locked(int32_t ticks, k_spinlock_key_t key)
 
 	announce_remaining = ticks;
 
-	struct _timeout *t;
+	struct _timeout *t = first();
 
-	for (t = first();
-	     (t != NULL) && (t->dticks <= announce_remaining);
-	     t = first()) {
+	while ((t != NULL) && (t->dticks <= announce_remaining)) {
 		int dt = t->dticks;
 
 		curr_tick += dt;
-		t->dticks = 0;
-		remove_timeout(t);
-		t->dticks = TIMEOUT_DTICKS_ANNOUNCING;
 
-		k_spin_unlock(&timeout_lock, key);
-		t->fn(t);
-		key = k_spin_lock(&timeout_lock);
+		/* Drain all timeouts queued on this tick before
+		 * decrementing announce_remaining.
+		 */
+		do {
+			_timeout_func_t handler = t->fn;
+
+			sys_dlist_remove(&t->node);
+			t->dticks = TIMEOUT_DTICKS_ANNOUNCING;
+
+			k_spin_unlock(&timeout_lock, key);
+			handler(t);
+			key = k_spin_lock(&timeout_lock);
+
+			t = first();
+		} while ((t != NULL) && (t->dticks == 0));
+
 		announce_remaining -= dt;
 	}
 

--- a/kernel/timer.c
+++ b/kernel/timer.c
@@ -87,9 +87,6 @@ void z_timer_expiration_handler(struct _timeout *t)
 	    !K_TIMEOUT_EQ(timer->period, K_FOREVER)) {
 		k_timeout_t next = timer->period;
 
-		/* see note about z_add_timeout() in z_impl_k_timer_start() */
-		next.ticks = max(next.ticks - 1, 0);
-
 #ifdef CONFIG_TIMEOUT_64BIT
 		/* Exploit the fact that uptime during a kernel
 		 * timeout handler reflects the time of the scheduled
@@ -98,11 +95,8 @@ void z_timer_expiration_handler(struct _timeout *t)
 		 * delayed for any reason, we still end up calculating
 		 * the next expiration as a regular stride from where
 		 * we "should" have run.  Requires absolute timeouts.
-		 * (Note offset by one: we're nominally at the
-		 * beginning of a tick, so need to defeat the "round
-		 * down" behavior on timeout addition).
 		 */
-		next = K_TIMEOUT_ABS_TICKS(k_uptime_ticks() + 1 + next.ticks);
+		next = K_TIMEOUT_ABS_TICKS(k_uptime_ticks() + next.ticks);
 #endif /* CONFIG_TIMEOUT_64BIT */
 		z_add_timeout(&timer->timeout, z_timer_expiration_handler,
 			      next);

--- a/kernel/timer.c
+++ b/kernel/timer.c
@@ -190,28 +190,6 @@ void z_impl_k_timer_start(struct k_timer *timer, k_timeout_t duration,
 		return;
 	}
 
-	/* z_add_timeout() always adds one to the incoming tick count
-	 * to round up to the next tick (by convention it waits for
-	 * "at least as long as the specified timeout"), but the
-	 * period interval is always guaranteed to be reset from
-	 * within the timer ISR, so no round up is desired and 1 is
-	 * subtracted in there.
-	 *
-	 * Note that the duration (!) value gets the same treatment
-	 * for backwards compatibility.  This is unfortunate
-	 * (i.e. k_timer_start() doesn't treat its initial sleep
-	 * argument the same way k_sleep() does), but historical.  The
-	 * timer_api test relies on this behavior.
-	 */
-	if (Z_IS_TIMEOUT_RELATIVE(duration)) {
-		/* For the duration == K_NO_WAIT case, ensure that behaviour
-		 * is consistent for both 32-bit k_ticks_t which are unsigned
-		 * and 64-bit k_ticks_t which are signed.
-		 */
-		duration.ticks = max(1, duration.ticks);
-		duration.ticks = duration.ticks - 1;
-	}
-
 	(void)z_abort_timeout(&timer->timeout);
 	timer->period = period;
 	timer->status = 0U;

--- a/kernel/timeslicing.c
+++ b/kernel/timeslicing.c
@@ -81,7 +81,7 @@ void z_reset_time_slice(struct k_thread *thread)
 	slice_expired[cpu] = false;
 	if (slice_size != 0) {
 		z_add_timeout(&slice_timeouts[cpu], slice_timeout,
-			      K_TICKS(slice_size - 1));
+			      K_TICKS(slice_size));
 	}
 }
 

--- a/kernel/timeslicing.c
+++ b/kernel/timeslicing.c
@@ -78,11 +78,18 @@ void z_reset_time_slice(struct k_thread *thread)
 	int slice_size = z_time_slice_size(thread);
 
 	z_abort_timeout(&slice_timeouts[cpu]);
-	slice_expired[cpu] = false;
 	if (slice_size != 0) {
+		/* When invoked because the slicer just fired (this CPU or
+		 * via IPI from another), we're at a tick edge but past the
+		 * announce window, so subtract 1 to cancel z_add_timeout()'s
+		 * "+1" round-up and land at exactly slice_size ticks.
+		 */
+		int delay = slice_expired[cpu] ? slice_size - 1 : slice_size;
+
 		z_add_timeout(&slice_timeouts[cpu], slice_timeout,
-			      K_TICKS(slice_size));
+			      K_TICKS(delay));
 	}
+	slice_expired[cpu] = false;
 }
 
 static ALWAYS_INLINE bool thread_defines_time_slice_size(struct k_thread *thread)
@@ -154,8 +161,25 @@ void z_time_slice(void)
 #endif
 		if (!z_is_thread_prevented_from_running(curr)) {
 			move_current_to_end_of_prio_q();
+			/* If the rotation kept curr at the front (no other
+			 * runnable thread of equal-or-higher priority is
+			 * waiting), no swap will happen and we must rearm
+			 * here. Otherwise the dispatch path will rearm for
+			 * the new thread with slice_expired still set,
+			 * picking up the tick-aligned delay.
+			 */
+#ifdef CONFIG_SMP
+			struct k_thread *next = runq_best();
+
+			if (next == NULL || z_is_idle_thread_object(next)) {
+				z_reset_time_slice(curr);
+			}
+#else
+			if (_kernel.ready_q.cache == curr) {
+				z_reset_time_slice(curr);
+			}
+#endif
 		}
-		z_reset_time_slice(curr);
 	}
 	k_spin_unlock(&_sched_spinlock, key);
 }

--- a/tests/kernel/context/src/main.c
+++ b/tests/kernel/context/src/main.c
@@ -233,7 +233,10 @@ static void _test_kernel_cpu_idle(int atomic)
 	uint64_t t0, dt;
 	unsigned int i, key;
 	uint32_t dur = k_ms_to_ticks_ceil32(10);
-	uint32_t slop = 1 + k_ms_to_ticks_ceil32(1);
+	/* 1 tick for z_add_timeout()'s "at least N" round-up, plus
+	 * 1 ms measurement slop.
+	 */
+	uint32_t slop = 2 + k_ms_to_ticks_ceil32(1);
 	int idle_loops;
 
 	/* Set up a time to trigger events to exit idle mode */

--- a/tests/kernel/threads/no-multithreading/src/main.c
+++ b/tests/kernel/threads/no-multithreading/src/main.c
@@ -48,10 +48,29 @@ ZTEST(no_multithreading, test_irq_locking)
 
 	unsigned int key = irq_lock();
 
-	k_busy_wait(15000);
+	/* Wait long enough to cover the 10 ms timeout plus one full
+	 * tick of slack for z_add_timeout()'s "at least N" round-up
+	 * plus a few ms of measurement margin.
+	 */
+	k_busy_wait(10000 + k_ticks_to_us_ceil32(1) + 5000);
 	zassert_false(timeout_run, "Timeout should not expire because irq is locked");
 
 	irq_unlock(key);
+
+	if (!IS_ENABLED(CONFIG_TICKLESS_KERNEL)) {
+		/*
+		 * On a tickful kernel, the timer ISR announces exactly one
+		 * tick per invocation. While IRQs were masked, multiple tick
+		 * interrupts fired but the IRQ controller's pending bit
+		 * coalesces them, so only a single ISR runs when IRQs are
+		 * unlocked. Our K_MSEC(10) timer needs two announces to
+		 * reach its deadline under the "at least N ticks" contract,
+		 * so the first pending delivery only brings dticks from 2
+		 * down to 1. Wait for the next tick so a second ISR fires
+		 * and the timer actually expires.
+		 */
+		k_busy_wait(k_ticks_to_us_ceil32(1) + 1000);
+	}
 
 	zassert_true(timeout_run, "Timeout should expire because irq got unlocked");
 }
@@ -68,11 +87,35 @@ ZTEST(no_multithreading, test_cpu_idle)
 	 */
 	k_timer_start(&timer, K_MSEC(10), K_NO_WAIT);
 
-	k_cpu_idle();
+	if (IS_ENABLED(CONFIG_TICKLESS_KERNEL)) {
+		/*
+		 * On a tickless kernel the only scheduled wakeup while
+		 * we are idle is our own timer, so k_cpu_idle() returns
+		 * once with the timer callback already executed.
+		 */
+		k_cpu_idle();
+		zassert_true(timeout_run, "Timeout should expire");
+	} else {
+		/*
+		 * On a tickful kernel periodic tick interrupts wake
+		 * k_cpu_idle() on every tick regardless of our timer.
+		 * Loop back to idle until the timer callback has actually
+		 * run, which under the "at least N ticks" contract may
+		 * take more than one tick for K_MSEC() values that round
+		 * to a single tick.
+		 */
+		while (!timeout_run) {
+			k_cpu_idle();
+		}
+	}
 
 	diff = k_uptime_get() - now;
-	zassert_true(timeout_run, "Timeout should expire");
-	zassert_within(diff, 10, 2, "Unexpected time passed: %d ms", (int)diff);
+	/* Timer fires at least 10 ms from now (minimum delay), at most
+	 * 10 ms plus one tick for the round-up in z_add_timeout() and
+	 * a couple of ms of measurement margin.
+	 */
+	zassert_between_inclusive(diff, 10, 10 + k_ticks_to_ms_ceil32(1) + 2,
+				  "Unexpected time passed: %d ms", (int)diff);
 }
 
 #define IDX_PRE_KERNEL_1 0

--- a/tests/kernel/timer/timer_api/src/main.c
+++ b/tests/kernel/timer/timer_api/src/main.c
@@ -91,6 +91,12 @@ static bool interval_check(int64_t interval, int64_t desired)
 {
 	int64_t slop = INEXACT_MS_CONVERT ? 1 : 0;
 
+	/* z_add_timeout() rounds up by one tick to guarantee "at least
+	 * N ticks" -- that can push the first fire a whole tick past
+	 * the nominal duration.
+	 */
+	slop += k_ticks_to_ms_ceil32(1);
+
 	/* Tickless kernels will advance time inside of an ISR, so it
 	 * is always possible (especially with high tick rates and
 	 * slow CPUs) for us to arrive at the uptime check above too

--- a/tests/kernel/workq/work/src/main.c
+++ b/tests/kernel/workq/work/src/main.c
@@ -731,9 +731,11 @@ ZTEST(work_1cpu, test_1cpu_running_cancel)
 	zassert_equal(coophi_counter(), 0);
 
 	/* Busy wait until timer expires. Thread context is blocked so cancelling
-	 * of work won't be completed.
+	 * of work won't be completed. Add one tick of slack on top of the
+	 * nominal timeout for the +1 round-up inside z_add_timeout() plus
+	 * 1 ms for general measurement jitter.
 	 */
-	k_busy_wait(1000 * (ms_timeout + 1));
+	k_busy_wait(1000 * ms_timeout + k_ticks_to_us_ceil32(1) + 1000);
 
 	zassert_equal(k_timer_status_get(&ctx->timer), 1);
 
@@ -793,9 +795,11 @@ ZTEST(work_1cpu, test_1cpu_running_cancel_sync)
 	zassert_equal(coophi_counter(), 1);
 
 	/* Busy wait until timer expires. Thread context is blocked so cancelling
-	 * of work won't be completed.
+	 * of work won't be completed. Add one tick of slack on top of the
+	 * nominal timeout for the +1 round-up inside z_add_timeout() plus
+	 * 1 ms for general measurement jitter.
 	 */
-	k_busy_wait(1000 * (ms_timeout + 1));
+	k_busy_wait(1000 * ms_timeout + k_ticks_to_us_ceil32(1) + 1000);
 
 	zassert_equal(k_timer_status_get(&ctx->timer), 1);
 


### PR DESCRIPTION
## Summary
- Backport timeout round-up handling fixes needed for timer behavior jitter/drift tests
- Backport k_timer_start documented minimum-duration semantics
- Backport Cortex-M SysTick absolute-cycle deadline scheduling
- Keep announce_remaining stable across same-tick timeout groups

## Testing
- User verified zephyr/tests/kernel/timer/timer_behavior test_jitter_drift_timer_startdelay passes after these backports

🤖 Generated with [Claude Code](https://claude.com/claude-code)