### PR TITLE
drivers: entropy: bee: include rng interface unconditionally

### DIFF
--- a/drivers/entropy/entropy_bee.c
+++ b/drivers/entropy/entropy_bee.c
@@ -9,11 +9,7 @@
 #include <zephyr/drivers/entropy.h>
 #include <string.h>
 
-#if defined(CONFIG_SOC_SERIES_RTL87X2J)
 #include <rng_interface.h>
-#else
-#include <utils.h>
-#endif
 
 static int entropy_bee_get_entropy(const struct device *dev, uint8_t *buffer, uint16_t length)
 {


### PR DESCRIPTION
All supported Bee SoCs now provide platform_random() from rng_interface.h.
Drop the RTL87x2J-only include split so G-series builds use it too.

Testing: not run (review and commit only).

🤖 Generated with [Claude Code](https://claude.com/claude-code)