### PR TITLE
boards: realtek: increase timeout multiplier

### DIFF
--- a/boards/realtek/rtl8752h_evb/rtl8752h_evb_rtl8752hjf.yaml
+++ b/boards/realtek/rtl8752h_evb/rtl8752h_evb_rtl8752hjf.yaml
@@ -23,4 +23,5 @@ supported:
 testing:
   ignore_tags:
     - pm
+  timeout_multiplier: 3
 vendor: realtek

--- a/boards/realtek/rtl8752h_evb/rtl8752h_evb_rtl8752hjl.yaml
+++ b/boards/realtek/rtl8752h_evb/rtl8752h_evb_rtl8752hjl.yaml
@@ -23,4 +23,5 @@ supported:
 testing:
   ignore_tags:
     - pm
+  timeout_multiplier: 3
 vendor: realtek

--- a/boards/realtek/rtl8752h_evb/rtl8752h_evb_rtl8752hkf.yaml
+++ b/boards/realtek/rtl8752h_evb/rtl8752h_evb_rtl8752hkf.yaml
@@ -23,4 +23,5 @@ supported:
 testing:
   ignore_tags:
     - pm
+  timeout_multiplier: 3
 vendor: realtek

--- a/boards/realtek/rtl8752h_evb/rtl8752h_evb_rtl8752hmf.yaml
+++ b/boards/realtek/rtl8752h_evb/rtl8752h_evb_rtl8752hmf.yaml
@@ -23,4 +23,5 @@ supported:
 testing:
   ignore_tags:
     - pm
+  timeout_multiplier: 3
 vendor: realtek

--- a/boards/realtek/rtl87x2g_evb_a/rtl87x2g_evb_a_rtl8762gkh.yaml
+++ b/boards/realtek/rtl87x2g_evb_a/rtl87x2g_evb_a_rtl8762gkh.yaml
@@ -23,4 +23,5 @@ supported:
 testing:
   ignore_tags:
     - pm
+  timeout_multiplier: 3
 vendor: realtek

--- a/boards/realtek/rtl87x2g_evb_a/rtl87x2g_evb_a_rtl8762gku.yaml
+++ b/boards/realtek/rtl87x2g_evb_a/rtl87x2g_evb_a_rtl8762gku.yaml
@@ -23,4 +23,5 @@ supported:
 testing:
   ignore_tags:
     - pm
+  timeout_multiplier: 3
 vendor: realtek

--- a/boards/realtek/rtl87x2g_evb_a/rtl87x2g_evb_a_rtl8762grh.yaml
+++ b/boards/realtek/rtl87x2g_evb_a/rtl87x2g_evb_a_rtl8762grh.yaml
@@ -23,4 +23,5 @@ supported:
 testing:
   ignore_tags:
     - pm
+  timeout_multiplier: 3
 vendor: realtek

--- a/boards/realtek/rtl87x2g_evb_a/rtl87x2g_evb_a_rtl8762gru.yaml
+++ b/boards/realtek/rtl87x2g_evb_a/rtl87x2g_evb_a_rtl8762gru.yaml
@@ -23,4 +23,5 @@ supported:
 testing:
   ignore_tags:
     - pm
+  timeout_multiplier: 3
 vendor: realtek


### PR DESCRIPTION
The secure_storage.psa.its.secure_storage.custom.transform test uses a common 600s timeout, but rtl87x2g needs about 1200s to finish max_num_entries on real hardware.

Raise Realtek Bee board multipliers to provide CI margin.

Testing:
- secure_storage.psa.its.secure_storage.custom.transform passed on rtl87x2g_evb_a/rtl8762gku in 1147.55s.
- Targeted compliance passed: BoardYml, Gitlint, GitDiffCheck, YAMLLint, Identity.
- Full compliance was run but failed on pre-existing/local issues: Kconfig undefined symbols, ModulesMaintainers, and untracked read_serial.py Ruff.

🤖 Generated with [Claude Code](https://claude.com/claude-code)