### PR TITLE
soc: realtek: move timer init to late hook

### DIFF
--- a/soc/realtek/bee/rtl8752h/soc.c
+++ b/soc/realtek/bee/rtl8752h/soc.c
@@ -137,17 +137,17 @@ void soc_early_init_hook(void)
 	power_manager_master_init();
 	power_manager_slave_init();
 	platform_pm_init();
+}
 
+void soc_late_init_hook(void)
+{
 	/* Initialize OSC32 SDM software timer. */
 	init_osc_sdm_timer();
 
 	/* Initialize PHY hardware control. */
 	phy_hw_control_init(false);
 	phy_init(false);
-}
 
-void soc_late_init_hook(void)
-{
 	/* Initialize HW AES mutex. */
 	hw_aes_create_mutex();
 

--- a/soc/realtek/bee/rtl87x2g/soc.c
+++ b/soc/realtek/bee/rtl87x2g/soc.c
@@ -190,6 +190,14 @@ void soc_early_init_hook(void)
 	power_manager_slave_init();
 	platform_pm_init();
 
+#ifdef CONFIG_TRUSTED_EXECUTION_NONSECURE
+	/* Route interrupts to Non-Secure state. */
+	setup_non_secure_nvic();
+#endif
+}
+
+void soc_late_init_hook(void)
+{
 	/* Initialize OSC32 SDM software timer. */
 	init_osc_sdm_timer();
 
@@ -203,14 +211,6 @@ void soc_early_init_hook(void)
 	/* Initialize thermal compensation tracking. */
 	thermal_tracking_timer_init();
 
-#ifdef CONFIG_TRUSTED_EXECUTION_NONSECURE
-	/* Route interrupts to Non-Secure state. */
-	setup_non_secure_nvic();
-#endif
-}
-
-void soc_late_init_hook(void)
-{
 	/* Initialize HW AES mutex. */
 	hw_aes_mutex_init();
 


### PR DESCRIPTION
Summary:
- Move Realtek SoC init steps that use kernel timers to late init.
- Keep timer-dependent init after Zephyr timer support is ready.
- Apply the init order adjustment to rtl8752h and rtl87x2g.

Testing:
- git diff --check -- soc/realtek/bee/rtl8752h/soc.c soc/realtek/bee/rtl87x2g/soc.c
- source ~/zephyrproject/.venv/bin/activate && ./scripts/ci/check_compliance.py -c HEAD~1..HEAD
  - Fails: Kconfig reports pre-existing undefined symbols outside this change.
  - Fails: ModulesMaintainers reports missing entry for West project: zephyr.
- Per user request, PR created against realtek-main-v4.4 despite the local compliance failures.

🤖 Generated with [Claude Code](https://claude.com/claude-code)