### PR TITLE
samples: drivers: ir: fix Bee sample platform

### DIFF
--- a/samples/drivers/ir/sample.yaml
+++ b/samples/drivers/ir/sample.yaml
@@ -7,7 +7,7 @@ tests:
     build_only: true
     platform_allow:
       - rtl8752h_evb/rtl8752hjl
-      - rtl87x2g_evb/a_rtl8762gku
+      - rtl87x2g_evb_a/rtl8762gku
       - rtl87x2j_evb/rtl8762jth
     integration_platforms:
       - rtl87x2j_evb/rtl8762jth


### PR DESCRIPTION
Summary:
- Fix the RTL8762GKU board target qualifier in the IR sample metadata.

🤖 Generated with [Claude Code](https://claude.com/claude-code)