### PR TITLE
tests: kernel: usage: bound peak growth by measured busy time

### DIFF
--- a/tests/kernel/usage/thread_runtime_stats/src/test_thread_runtime_stats.c
+++ b/tests/kernel/usage/thread_runtime_stats/src/test_thread_runtime_stats.c
@@ -162,13 +162,24 @@ ZTEST(usage_api, test_all_stats_usage)
 	zassert_true(stats4.current_cycles <= stats1.current_cycles);
 	zassert_true(stats5.current_cycles > stats4.current_cycles);
 
-	/* The peak busy stretch is the same one before and after it closed; it
-	 * only grew by the sub-tick measurement tail between the stats3 sample
-	 * and the idle event. Scheduling here is tick aligned, so comparing in
-	 * the tick domain makes that tail vanish, no percentage tolerance needed.
+	/* stats3 sampled this busy stretch mid-way and stats4 after the idle
+	 * event closed it, so peak grew only by the CPU-busy time that elapsed
+	 * between the two samples. That busy time is exactly the growth in
+	 * total_cycles: peak (longest) and total are advanced from the same cycle
+	 * deltas, so peak can never grow by more than total. Bounding peak growth
+	 * by it needs no tolerance and no per-platform value, self-scales with the
+	 * clock, and still catches a spurious jump at the idle event.
 	 */
-	zassert_equal(k_cyc_to_ticks_near64(stats4.peak_cycles),
-		      k_cyc_to_ticks_near64(stats3.peak_cycles), NULL);
+	zassert_true(stats4.peak_cycles >= stats3.peak_cycles,
+		     "peak_cycles shrank across the idle event: %llu -> %llu",
+		     (unsigned long long)stats3.peak_cycles,
+		     (unsigned long long)stats4.peak_cycles);
+	zassert_true((stats4.peak_cycles - stats3.peak_cycles) <=
+			     (stats4.total_cycles - stats3.total_cycles),
+		     "peak grew by %llu cycles but only %llu busy cycles elapsed "
+		     "between the samples",
+		     (unsigned long long)(stats4.peak_cycles - stats3.peak_cycles),
+		     (unsigned long long)(stats4.total_cycles - stats3.total_cycles));
 	zassert_true(stats4.peak_cycles == stats5.peak_cycles);
 
 	zassert_true(stats4.average_cycles > 0);


### PR DESCRIPTION
Backport upstream commit bde6374f13f1b5ad19781eac2b9f44d158888d98 to
realtek-main-v4.4.

This fixes the thread runtime stats test by bounding peak_cycles growth by
the measured CPU-busy time between samples instead of comparing samples
rounded to the nearest tick.

Testing:
- git diff --check HEAD~1..HEAD
- Commit title/body line length check
- west build -p always -b rtl87x2j_evb/rtl8762jth tests/kernel/usage/thread_runtime_stats
- ./scripts/ci/check_compliance.py (failed: unrelated Kconfig undefined
  symbols and ModulesMaintainers "West project: zephyr" issue; proceeded
  by request)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
