### PR TITLE
samples: cmsis_dsp: fix moving average on Helium

### DIFF
--- a/samples/modules/cmsis_dsp/moving_average/src/main.c
+++ b/samples/modules/cmsis_dsp/moving_average/src/main.c
@@ -11,15 +11,25 @@
 
 #define NUM_TAPS   10 /* Number of taps in the FIR filter (length of the moving average window) */
 #define BLOCK_SIZE 32 /* Number of samples processed per block */
+#define ROUND_UP_4(x) (((x) + 3) & ~3)
+
+#if defined(ARM_MATH_MVEI) && !defined(ARM_MATH_AUTOVECTORIZE)
+#define NUM_TAPS_ARRAY ROUND_UP_4(NUM_TAPS)
+#define FIR_STATE_SIZE (NUM_TAPS + BLOCK_SIZE - 1 + (2 * ROUND_UP_4(BLOCK_SIZE)))
+#else
+#define NUM_TAPS_ARRAY NUM_TAPS
+#define FIR_STATE_SIZE (NUM_TAPS + BLOCK_SIZE - 1)
+#endif
 
 /*
  * Filter coefficients are all equal for a moving average filter. Here, 1/NUM_TAPS = 0.1f.
+ * The Helium version requires the coefficient array to be padded to a multiple of 4.
  */
-q31_t firCoeffs[NUM_TAPS] = {0x0CCCCCCD, 0x0CCCCCCD, 0x0CCCCCCD, 0x0CCCCCCD, 0x0CCCCCCD,
-			     0x0CCCCCCD, 0x0CCCCCCD, 0x0CCCCCCD, 0x0CCCCCCD, 0x0CCCCCCD};
+q31_t firCoeffs[NUM_TAPS_ARRAY] = {0x0CCCCCCD, 0x0CCCCCCD, 0x0CCCCCCD, 0x0CCCCCCD, 0x0CCCCCCD,
+				   0x0CCCCCCD, 0x0CCCCCCD, 0x0CCCCCCD, 0x0CCCCCCD, 0x0CCCCCCD};
 
 arm_fir_instance_q31 sFIR;
-q31_t firState[NUM_TAPS + BLOCK_SIZE - 1];
+q31_t firState[FIR_STATE_SIZE];
 
 int main(void)
 {


### PR DESCRIPTION
TO reproduce:

```sh
west build -b rtl87x2g_evb_a/rtl8762gku \
  samples/modules/cmsis_dsp/moving_average -p
```

The code hangs at:

```c
arm_fir_q31(&sFIR, input, output, BLOCK_SIZE);
```

RTL87x2G uses a Cortex-M55 core with MVE support. The CMSIS-DSP
Helium FIR Q31 implementation requires extra state buffer space and
requires the coefficient array to be padded to a multiple of four
entries, so the sample needs to size those buffers accordingly.

After this change, the case can pass:

```text
(.venv) zhiyuan@A207151515:~$ rtkprog -b 115200 --port /dev/ttyUSB0 terminal
*** Booting Zephyr OS build v4.4.0-163-gddbd99c7efe6 ***
Time: 312 us (10 cycles)
Input[00]:  0  0  0  0  0  0  0  0  0  0 | Output[00]:   0.00
Input[01]:  0  0  0  0  0  0  0  0  0  1 | Output[01]:   0.10
Input[02]:  0  0  0  0  0  0  0  0  1  2 | Output[02]:   0.30
Input[03]:  0  0  0  0  0  0  0  1  2  3 | Output[03]:   0.60
Input[04]:  0  0  0  0  0  0  1  2  3  4 | Output[04]:   1.00
Input[05]:  0  0  0  0  0  1  2  3  4  5 | Output[05]:   1.50
Input[06]:  0  0  0  0  1  2  3  4  5  6 | Output[06]:   2.10
Input[07]:  0  0  0  1  2  3  4  5  6  7 | Output[07]:   2.80
Input[08]:  0  0  1  2  3  4  5  6  7  8 | Output[08]:   3.60
Input[09]:  0  1  2  3  4  5  6  7  8  9 | Output[09]:   4.50
Input[10]:  1  2  3  4  5  6  7  8  9 10 | Output[10]:   5.50
Input[11]:  2  3  4  5  6  7  8  9 10 11 | Output[11]:   6.50
Input[12]:  3  4  5  6  7  8  9 10 11 12 | Output[12]:   7.50
Input[13]:  4  5  6  7  8  9 10 11 12 13 | Output[13]:   8.50
Input[14]:  5  6  7  8  9 10 11 12 13 14 | Output[14]:   9.50
Input[15]:  6  7  8  9 10 11 12 13 14 15 | Output[15]:  10.50
Input[16]:  7  8  9 10 11 12 13 14 15 16 | Output[16]:  11.50
Input[17]:  8  9 10 11 12 13 14 15 16 17 | Output[17]:  12.50
Input[18]:  9 10 11 12 13 14 15 16 17 18 | Output[18]:  13.50
Input[19]: 10 11 12 13 14 15 16 17 18 19 | Output[19]:  14.50
Input[20]: 11 12 13 14 15 16 17 18 19 20 | Output[20]:  15.50
Input[21]: 12 13 14 15 16 17 18 19 20 21 | Output[21]:  16.50
Input[22]: 13 14 15 16 17 18 19 20 21 22 | Output[22]:  17.50
Input[23]: 14 15 16 17 18 19 20 21 22 23 | Output[23]:  18.50
Input[24]: 15 16 17 18 19 20 21 22 23 24 | Output[24]:  19.50
Input[25]: 16 17 18 19 20 21 22 23 24 25 | Output[25]:  20.50
Input[26]: 17 18 19 20 21 22 23 24 25 26 | Output[26]:  21.50
Input[27]: 18 19 20 21 22 23 24 25 26 27 | Output[27]:  22.50
Input[28]: 19 20 21 22 23 24 25 26 27 28 | Output[28]:  23.50
Input[29]: 20 21 22 23 24 25 26 27 28 29 | Output[29]:  24.50
Input[30]: 21 22 23 24 25 26 27 28 29 30 | Output[30]:  25.50
Input[31]: 22 23 24 25 26 27 28 29 30 31 | Output[31]:  26.50
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
