### PR TITLE
soc: realtek: rtl8752h: support sys_reboot()

### DIFF
--- a/soc/realtek/bee/rtl8752h/Kconfig.defconfig.series
+++ b/soc/realtek/bee/rtl8752h/Kconfig.defconfig.series
@@ -15,6 +15,9 @@ config SYS_CLOCK_HW_CYCLES_PER_SEC
 config SYS_CLOCK_TICKS_PER_SEC
 	default 1000
 
+config ARCH_HAS_CUSTOM_BUSY_WAIT
+	default y
+
 if BT
 
 config NUM_METAIRQ_PRIORITIES

--- a/soc/realtek/bee/rtl8752h/soc.c
+++ b/soc/realtek/bee/rtl8752h/soc.c
@@ -6,6 +6,7 @@
 
 #include <zephyr/kernel.h>
 #include <zephyr/linker/linker-defs.h>
+#include <zephyr/sys/reboot.h>
 #include <zephyr/logging/log.h>
 #include <soc.h>
 
@@ -17,13 +18,12 @@
 #include "system_rtl876x.h"
 #include "vector_table.h"
 #include "rtl876x_aon_reg.h"
+#include "sys_reset.h"
 
 extern void _isr_wrapper(void);
 
 #define RAM_VECTOR_ADDR   (0x200000)
 #define STACK_ROM_ADDRESS DT_REG_ADDR(DT_NODELABEL(bee_bt_controller))
-
-typedef bool (*BOOL_PATCH_FUNC)(void);
 
 LOG_MODULE_REGISTER(soc, CONFIG_SOC_LOG_LEVEL);
 
@@ -173,4 +173,16 @@ void soc_late_init_hook(void)
 	rtl8752h_isr_register();
 
 	rtl_boot_stage_record(PON_BOOT_DONE);
+}
+
+/* Overrides the weak ARM implementation */
+void sys_arch_reboot(int type)
+{
+	/* Convert SYS_REBOOT_WARM (0) to RESET_ALL_EXCEPT_AON (1).
+	 * Convert SYS_REBOOT_COLD (1) to RESET_ALL (0).
+	 */
+	int wdt_mode = (type == SYS_REBOOT_WARM) ? RESET_ALL_EXCEPT_AON : RESET_ALL;
+
+	/* Call the watchdog system reset with the converted mode and reset reason. */
+	WDG_SystemReset(wdt_mode, RESET_REASON_ZEPHYR);
 }

--- a/soc/realtek/bee/rtl8752h/soc.c
+++ b/soc/realtek/bee/rtl8752h/soc.c
@@ -16,6 +16,7 @@
 #include "rtl_boot_record.h"
 #include "system_rtl876x.h"
 #include "vector_table.h"
+#include "rtl876x_aon_reg.h"
 
 extern void _isr_wrapper(void);
 
@@ -117,8 +118,19 @@ void soc_early_init_hook(void)
 
 	work_around_32k_power_glitch();
 
-	/* Restart power sequence to latch new settings. */
-	pmu_power_on_sequence_restart();
+	/* RTK PM: use aon_boot_done to distinguish between Power Down mode
+	 * wakeup and HW reset/first boot.
+	 */
+	AON_FAST_REG_REG0X_FW_GENERAL_TYPE aon_fast_boot = {
+		.d16 = btaon_fast_read(AON_FAST_REG_REG0X_FW_GENERAL)};
+	bool aon_boot_done = aon_fast_boot.aon_boot_done;
+
+	if (!aon_boot_done) {
+		/* Restart power sequence to latch new settings. */
+		pmu_power_on_sequence_restart();
+	} else {
+		/* TODO: Power Down mode resume flow (si flow exit, PMU exit) */
+	}
 
 	si_flow_after_power_on_sequence_restart();
 

--- a/soc/realtek/bee/rtl87x2g/soc.c
+++ b/soc/realtek/bee/rtl87x2g/soc.c
@@ -22,6 +22,7 @@
 #include "image_info.h"
 #include "image_check.h"
 #include "rom_uuid.h"
+#include "aon_reg.h"
 
 LOG_MODULE_REGISTER(soc, CONFIG_SOC_LOG_LEVEL);
 
@@ -131,7 +132,6 @@ static void rtl87x2g_isr_register(void)
 
 	irq_unlock(key);
 }
-
 void soc_early_init_hook(void)
 {
 	/* [Phase 1] Vector Table Relocation:
@@ -168,8 +168,18 @@ void soc_early_init_hook(void)
 	/* Apply PMU voltage tuning (LDO/PWM/PFM). */
 	pmu_apply_voltage_tune();
 
-	/* Restart power sequence to latch new settings. */
-	pmu_power_on_sequence_restart();
+	/* RTK PM: use km4_aon_boot_done to distinguish between Power Down mode
+	 * wakeup and HW reset/first boot.
+	 */
+	bool aon_boot_done = AON_REG_READ_BITFIELD(AON_NS_REG0X_FW_GENERAL_NS, km4_aon_boot_done);
+
+	if (!aon_boot_done) {
+		/* Restart power sequence to latch new settings. */
+		pmu_power_on_sequence_restart();
+	} else {
+		/* TODO: Power Down mode resume flow (si flow exit, PMU exit) */
+	}
+	AON_REG_WRITE_BITFIELD(AON_NS_REG0X_FW_GENERAL_NS, km4_aon_boot_done, 1);
 
 	/* Initialize HAL hardware (RXI300) and CPU features (DWT, FPU). */
 	hal_setup_hardware();
@@ -222,6 +232,9 @@ void soc_late_init_hook(void)
 	 * Register ROM-installed ISRs to Zephyr and restore _isr_wrapper.
 	 */
 	rtl87x2g_isr_register();
+
+	/* RTK PM: mark boot done. Used to distinguish HW reset from DLPS wakeup. */
+	AON_REG_WRITE_BITFIELD(AON_NS_REG0X_FW_GENERAL_NS, km4_pon_boot_done, 1);
 }
 
 #ifdef CONFIG_ARCH_HAS_CUSTOM_BUSY_WAIT


### PR DESCRIPTION
This PR updates the Realtek Bee v4.4 SoC support for reset and wakeup handling.

It adds Power Down mode wakeup handling for Bee SoCs by checking the AON boot-done state during early initialization, and it adds `sys_reboot()` support for RTL8752H through the SoC `sys_arch_reboot()` hook.

The task watchdog sample was used to validate the reboot path because it exercises Zephyr's `sys_reboot()` API. Both RTL8752H and RTL87x2G passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
