### PR TITLE
soc: realtek: rtl8752h: use default busy wait

### DIFF
--- a/soc/realtek/bee/rtl8752h/Kconfig.defconfig.series
+++ b/soc/realtek/bee/rtl8752h/Kconfig.defconfig.series
@@ -15,9 +15,6 @@ config SYS_CLOCK_HW_CYCLES_PER_SEC
 config SYS_CLOCK_TICKS_PER_SEC
 	default 1000
 
-config ARCH_HAS_CUSTOM_BUSY_WAIT
-	default y
-
 if BT
 
 config NUM_METAIRQ_PRIORITIES


### PR DESCRIPTION
Remove the custom busy wait selection from RTL8752H so the SoC uses the default Zephyr busy wait implementation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
