### PR TITLE
samples: mpu_test: use word-aligned addresses in shell test

### DIFF
--- a/samples/arch/mpu/mpu_test/test_shell.yml
+++ b/samples/arch/mpu/mpu_test/test_shell.yml
@@ -1,4 +1,4 @@
-- command: "mpu mtest 1"
+- command: "mpu mtest 0"
   expected: "The value is: 0x.*"
-- command: "mpu mtest 2"
+- command: "mpu mtest 4"
   expected: "The value is: 0x.*"


### PR DESCRIPTION
Cherry-pick of upstream PR #115042
(zephyrproject-rtos/zephyr#115042)

The shell harness passes addresses `1` and `2` to `mpu mtest`,
which performs a 32-bit word read from those addresses.

`0x1` and `0x2` are not word-aligned. ARMv6-M (Cortex-M0+)
strictly prohibits unaligned word accesses and raises a HardFault
immediately, halting the system. The harness then times out waiting
for the shell prompt to return:

  AssertionError: Did not find "uart:~$ " within 20.0 seconds

This was observed on RTL8752H (Cortex-M0+) in nightly HIL testing,
where `sample.mpu.mpu_test` consistently failed while the same
test passed on RTL87x2G (Cortex-M55) and RTL87x2J (Cortex-M33),
both of which handle unaligned accesses transparently in hardware.

Replace `0x1`/`0x2` with word-aligned `0x0`/`0x4`. These
addresses fall inside the ROM/Flash region present on all supported
ARM platforms. The expected pattern `"The value is: 0x.*"` does
not constrain the value, so platforms returning different ROM
contents all pass correctly.

Observed on RTL8752H (Cortex-M0+):
- Before: HardFault + system halt -> FAILED
- After:  "The value is: 0x..." printed -> PASSED

🤖 Generated with [Claude Code](https://claude.com/claude-code)